### PR TITLE
chore: update some outdated deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "1", default-features = false }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-serde-saphyr = "0.0.11"
+serde-saphyr = "0.0.13"
 bitcode = { version = "0.6", features = ["serde"] }
 bincode = { version = "2", features = ["serde", "alloc"] }
 rkyv = { version = "0.8", features = ["bytecheck", "alloc", "bytes-1"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -29,8 +29,8 @@ hitbox-configuration = { path = "../hitbox-configuration" }
 hitbox-reqwest = { path = "../hitbox-reqwest" }
 hitbox-feoxdb = { path = "../hitbox-feoxdb" }
 
-reqwest = { version = "0.12", features = ["json"] }
-reqwest-middleware = "0.4"
+reqwest = { version = "0.13", features = ["json"] }
+reqwest-middleware = "0.5"
 
 actix = "0.13"
 axum = { workspace = true }

--- a/hitbox-reqwest/Cargo.toml
+++ b/hitbox-reqwest/Cargo.toml
@@ -35,8 +35,8 @@ hitbox-moka = { path = "../hitbox-moka", version = "0.1", optional = true }
 hitbox-redis = { path = "../hitbox-redis", version = "0.1", optional = true }
 hitbox-feoxdb = { path = "../hitbox-feoxdb", version = "0.1", optional = true }
 
-reqwest = { version = "0.12", default-features = false }
-reqwest-middleware = "0.4"
+reqwest = { version = "0.13", default-features = false }
+reqwest-middleware = "0.5"
 async-trait = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }

--- a/hitbox-test/Cargo.toml
+++ b/hitbox-test/Cargo.toml
@@ -37,7 +37,7 @@ http = { workspace = true }
 bytes = { workspace = true }
 axum = { workspace = true, features = ["macros"] }
 axum-test = "18.2"
-reqwest = "0.12"
+reqwest = "0.13"
 cucumber = { version = "0.22", features = ["output-junit", "libtest"] }
 serde-saphyr = { workspace = true }
 serde_yaml = "0.9"

--- a/hitbox/Cargo.toml
+++ b/hitbox/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { workspace = true, features = ["rt", "sync", "time"] }
 dashmap = { workspace = true }
 smol_str = { workspace = true }
 humantime-serde = "1"
-bounded-integer = { version = "0.5", features = ["macro", "serde"] }
+bounded-integer = { version = "0.6", features = ["macro", "serde1"] }
 
 [features]
 default = []

--- a/hitbox/src/policy.rs
+++ b/hitbox/src/policy.rs
@@ -1,14 +1,11 @@
 use std::time::Duration;
 
-use bounded_integer::bounded_integer;
+use bounded_integer::BoundedU8;
 use serde::{Deserialize, Serialize};
 
-bounded_integer! {
-    /// Concurrency limit for dogpile prevention (1-255).
-    /// A value of 1 means only one request can fetch from upstream at a time.
-    #[repr(u8)]
-    pub struct ConcurrencyLimit { 1..=255 }
-}
+/// Concurrency limit for dogpile prevention (1-255).
+/// A value of 1 means only one request can fetch from upstream at a time.
+pub type ConcurrencyLimit = BoundedU8<1, 255>;
 
 /// Policy for handling stale cache entries.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, Default)]


### PR DESCRIPTION
## Summary

Updates outdated dependencies from dependabot PRs:

- **serde-saphyr** 0.0.11 → 0.0.13
- **bounded-integer** 0.5 → 0.6 (includes code migration from `bounded_integer!` macro to `BoundedU8` type alias)
- **reqwest** 0.12 → 0.13
- **reqwest-middleware** 0.4 → 0.5

### Skipped

- **bincode** 2 → 3: Skipped because bincode 3.0.0 is an "end of maintenance" release (project abandoned). Will evaluate alternatives separately.

## Closes

Closes #171
Closes #156
Closes #170
Closes #174