### PR TITLE
Fix FeOxDB delete race by using atomic remove

### DIFF
--- a/hitbox-feoxdb/src/backend.rs
+++ b/hitbox-feoxdb/src/backend.rs
@@ -359,15 +359,10 @@ where
             .map_err(|e| BackendError::InternalError(Box::new(e)))?;
 
         tokio::task::spawn_blocking(move || {
-            let exists = store.contains_key(&key_bytes);
-
-            if exists {
-                store
-                    .delete(&key_bytes)
-                    .map_err(|e| BackendError::InternalError(Box::new(e)))?;
-                Ok(DeleteStatus::Deleted(1))
-            } else {
-                Ok(DeleteStatus::Missing)
+            match store.delete(&key_bytes) {
+                Ok(()) => Ok(DeleteStatus::Deleted(1)),
+                Err(FeoxError::KeyNotFound) => Ok(DeleteStatus::Missing),
+                Err(e) => Err(BackendError::InternalError(Box::new(e))),
             }
         })
         .await


### PR DESCRIPTION
**Summary**
- replace the contains_key+delete combination with a single `delete` call that handles missing keys explicitly
- treat `KeyNotFound` as a missing record and bubble other errors as internal failures

**Testing**
- Not run