### PR TITLE
Add multi-config support to Cache layer

### DIFF
--- a/hitbox-configuration/src/config.rs
+++ b/hitbox-configuration/src/config.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, sync::Arc};
 
-use hitbox::policy::PolicyConfig;
+use hitbox::{config::MultiConfig, policy::PolicyConfig};
 use hitbox_http::{
     extractors::{NeutralExtractor, method::MethodExtractor, path::PathExtractor},
     predicates::{
@@ -18,6 +18,20 @@ use crate::{
     types::MaybeUndefined,
 };
 
+/// Single route configuration for a cache layer.
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Default)]
+pub struct ConfigRoute {
+    #[serde(default)]
+    pub request: MaybeUndefined<Request>,
+    #[serde(default)]
+    pub response: MaybeUndefined<Response>,
+    #[serde(default)]
+    pub extractors: MaybeUndefined<Vec<Extractor>>,
+    #[serde(default)]
+    pub policy: PolicyConfig,
+}
+
+/// Config endpoint that supports both single-config and multi-config (`routes`) modes.
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Default)]
 pub struct ConfigEndpoint {
     #[serde(default)]
@@ -26,26 +40,36 @@ pub struct ConfigEndpoint {
     pub response: MaybeUndefined<Response>,
     #[serde(default)]
     pub extractors: MaybeUndefined<Vec<Extractor>>,
+    #[serde(default)]
     pub policy: PolicyConfig,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub routes: Vec<ConfigRoute>,
 }
 
 impl ConfigEndpoint {
+    fn has_inline_configuration(&self) -> bool {
+        !matches!(self.request, MaybeUndefined::Undefined)
+            || !matches!(self.response, MaybeUndefined::Undefined)
+            || !matches!(self.extractors, MaybeUndefined::Undefined)
+            || self.policy != PolicyConfig::default()
+    }
+
+    fn into_inline_route(self) -> ConfigRoute {
+        ConfigRoute {
+            request: self.request,
+            response: self.response,
+            extractors: self.extractors,
+            policy: self.policy,
+        }
+    }
+
     pub fn extractors<ReqBody>(&self) -> Result<RequestExtractor<ReqBody>, ConfigError>
     where
         ReqBody: hyper::body::Body + Send + Debug + 'static,
         ReqBody::Error: Debug + Send,
         ReqBody::Data: Send,
     {
-        match &self.extractors {
-            MaybeUndefined::Null => Ok(Box::new(NeutralExtractor::<ReqBody>::new())),
-            MaybeUndefined::Undefined => Ok(Box::new(
-                NeutralExtractor::<ReqBody>::new().method().path("{path}*"),
-            )),
-            MaybeUndefined::Value(extractors) => extractors.iter().cloned().try_rfold(
-                Box::new(NeutralExtractor::<ReqBody>::new()) as RequestExtractor<ReqBody>,
-                |inner, item| item.into_extractors(inner),
-            ),
-        }
+        build_extractors(&self.extractors)
     }
 
     pub fn into_endpoint<ReqBody, ResBody>(self) -> Result<Endpoint<ReqBody, ResBody>, ConfigError>
@@ -57,32 +81,142 @@ impl ConfigEndpoint {
         ResBody::Error: Debug + Send,
         ResBody::Data: Send,
     {
-        let extractors = Arc::new(self.extractors()?);
-        let response_predicates = Arc::new(match self.response {
-            MaybeUndefined::Value(response) => response.into_predicates()?,
-            MaybeUndefined::Null => {
-                Box::new(NeutralResponsePredicate::<ResBody>::new()) as ResponsePredicate<ResBody>
-            }
-            MaybeUndefined::Undefined => {
-                Box::new(NeutralResponsePredicate::<ResBody>::new().status_code(StatusCode::OK))
-                    as ResponsePredicate<ResBody>
-            }
-        });
-        let request_predicates = Arc::new(match self.request {
-            MaybeUndefined::Value(request) => request.into_predicates()?,
-            MaybeUndefined::Null => {
-                Box::new(NeutralRequestPredicate::<ReqBody>::new()) as RequestPredicate<ReqBody>
-            }
-            MaybeUndefined::Undefined => {
-                Box::new(NeutralRequestPredicate::<ReqBody>::new().method(Method::GET))
-                    as RequestPredicate<ReqBody>
-            }
-        });
-        Ok(Endpoint {
-            extractors,
-            request_predicates,
-            response_predicates,
-            policy: self.policy,
-        })
+        let has_inline_configuration = self.has_inline_configuration();
+        let route_count = self.routes.len();
+
+        if route_count == 0 {
+            return self.into_inline_route().into_endpoint();
+        }
+
+        if has_inline_configuration {
+            return Err(ConfigError::MixedRouteAndInlineConfig);
+        }
+
+        if route_count > 1 {
+            return Err(ConfigError::MultipleRouteConfigurations(route_count));
+        }
+
+        self.routes
+            .into_iter()
+            .next()
+            .expect("route_count checked")
+            .into_endpoint()
     }
+
+    pub fn into_routed_endpoint<ReqBody, ResBody>(
+        self,
+    ) -> Result<MultiConfig<Endpoint<ReqBody, ResBody>>, ConfigError>
+    where
+        ReqBody: hyper::body::Body + Send + Unpin + Debug + 'static,
+        ReqBody::Error: Debug + Send,
+        ReqBody::Data: Send,
+        ResBody: hyper::body::Body + Send + Unpin + 'static,
+        ResBody::Error: Debug + Send,
+        ResBody::Data: Send,
+    {
+        if self.routes.is_empty() {
+            return Ok(MultiConfig::new(vec![
+                self.into_inline_route().into_endpoint()?,
+            ]));
+        }
+
+        if self.has_inline_configuration() {
+            return Err(ConfigError::MixedRouteAndInlineConfig);
+        }
+
+        let endpoints = self
+            .routes
+            .into_iter()
+            .map(ConfigRoute::into_endpoint)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(MultiConfig::new(endpoints))
+    }
+}
+
+impl ConfigRoute {
+    pub fn extractors<ReqBody>(&self) -> Result<RequestExtractor<ReqBody>, ConfigError>
+    where
+        ReqBody: hyper::body::Body + Send + Debug + 'static,
+        ReqBody::Error: Debug + Send,
+        ReqBody::Data: Send,
+    {
+        build_extractors(&self.extractors)
+    }
+
+    pub fn into_endpoint<ReqBody, ResBody>(self) -> Result<Endpoint<ReqBody, ResBody>, ConfigError>
+    where
+        ReqBody: hyper::body::Body + Send + Unpin + Debug + 'static,
+        ReqBody::Error: Debug + Send,
+        ReqBody::Data: Send,
+        ResBody: hyper::body::Body + Send + Unpin + 'static,
+        ResBody::Error: Debug + Send,
+        ResBody::Data: Send,
+    {
+        build_endpoint(self.request, self.response, self.extractors, self.policy)
+    }
+}
+
+fn build_extractors<ReqBody>(
+    extractors: &MaybeUndefined<Vec<Extractor>>,
+) -> Result<RequestExtractor<ReqBody>, ConfigError>
+where
+    ReqBody: hyper::body::Body + Send + Debug + 'static,
+    ReqBody::Error: Debug + Send,
+    ReqBody::Data: Send,
+{
+    match extractors {
+        MaybeUndefined::Null => Ok(Box::new(NeutralExtractor::<ReqBody>::new())),
+        MaybeUndefined::Undefined => Ok(Box::new(
+            NeutralExtractor::<ReqBody>::new().method().path("{path}*"),
+        )),
+        MaybeUndefined::Value(extractors) => extractors.iter().cloned().try_rfold(
+            Box::new(NeutralExtractor::<ReqBody>::new()) as RequestExtractor<ReqBody>,
+            |inner, item| item.into_extractors(inner),
+        ),
+    }
+}
+
+fn build_endpoint<ReqBody, ResBody>(
+    request: MaybeUndefined<Request>,
+    response: MaybeUndefined<Response>,
+    extractors: MaybeUndefined<Vec<Extractor>>,
+    policy: PolicyConfig,
+) -> Result<Endpoint<ReqBody, ResBody>, ConfigError>
+where
+    ReqBody: hyper::body::Body + Send + Unpin + Debug + 'static,
+    ReqBody::Error: Debug + Send,
+    ReqBody::Data: Send,
+    ResBody: hyper::body::Body + Send + Unpin + 'static,
+    ResBody::Error: Debug + Send,
+    ResBody::Data: Send,
+{
+    let extractors = Arc::new(build_extractors::<ReqBody>(&extractors)?);
+    let response_predicates = Arc::new(match response {
+        MaybeUndefined::Value(response) => response.into_predicates()?,
+        MaybeUndefined::Null => {
+            Box::new(NeutralResponsePredicate::<ResBody>::new()) as ResponsePredicate<ResBody>
+        }
+        MaybeUndefined::Undefined => {
+            Box::new(NeutralResponsePredicate::<ResBody>::new().status_code(StatusCode::OK))
+                as ResponsePredicate<ResBody>
+        }
+    });
+    let request_predicates = Arc::new(match request {
+        MaybeUndefined::Value(request) => request.into_predicates()?,
+        MaybeUndefined::Null => {
+            Box::new(NeutralRequestPredicate::<ReqBody>::new()) as RequestPredicate<ReqBody>
+        }
+        MaybeUndefined::Undefined => {
+            Box::new(NeutralRequestPredicate::<ReqBody>::new().method(Method::GET))
+                as RequestPredicate<ReqBody>
+        }
+    });
+
+    Ok(Endpoint {
+        extractors,
+        request_predicates,
+        response_predicates,
+        policy,
+    })
 }

--- a/hitbox-configuration/src/endpoint.rs
+++ b/hitbox-configuration/src/endpoint.rs
@@ -1,8 +1,9 @@
 use std::{fmt::Debug, sync::Arc};
 
+use async_trait::async_trait;
 use hitbox::{
     Extractor, Predicate,
-    config::{BoxExtractor, BoxPredicate, CacheConfig},
+    config::{BoxExtractor, BoxPredicate, CacheConfig, CacheConfigRouter, RouteMatch},
     policy::PolicyConfig,
 };
 use hitbox_http::{CacheableHttpRequest, CacheableHttpResponse};
@@ -12,6 +13,7 @@ use crate::ConfigEndpoint;
 pub type RequestPredicate<ReqBody> = BoxPredicate<CacheableHttpRequest<ReqBody>>;
 pub type ResponsePredicate<ResBody> = BoxPredicate<CacheableHttpResponse<ResBody>>;
 pub type RequestExtractor<ReqBody> = BoxExtractor<CacheableHttpRequest<ReqBody>>;
+pub type RoutedEndpoint<ReqBody, ResBody> = hitbox::config::MultiConfig<Endpoint<ReqBody, ResBody>>;
 
 pub type ArcRequestPredicate<ReqBody> =
     Arc<dyn Predicate<Subject = CacheableHttpRequest<ReqBody>> + Send + Sync>;
@@ -105,6 +107,41 @@ where
 
     fn policy(&self) -> &PolicyConfig {
         &self.policy
+    }
+}
+
+#[async_trait]
+impl<ReqBody, ResBody>
+    CacheConfigRouter<CacheableHttpRequest<ReqBody>, CacheableHttpResponse<ResBody>>
+    for Endpoint<ReqBody, ResBody>
+where
+    ReqBody: hyper::body::Body + Send + 'static,
+    ReqBody::Error: Send,
+    ReqBody::Data: Send,
+    ResBody: hyper::body::Body + Send + 'static,
+    ResBody::Error: Send,
+    ResBody::Data: Send,
+{
+    type RequestPredicate = ArcRequestPredicate<ReqBody>;
+    type ResponsePredicate = ArcResponsePredicate<ResBody>;
+    type Extractor = ArcRequestExtractor<ReqBody>;
+
+    async fn route(
+        &self,
+        request: CacheableHttpRequest<ReqBody>,
+    ) -> RouteMatch<
+        CacheableHttpRequest<ReqBody>,
+        Self::RequestPredicate,
+        Self::ResponsePredicate,
+        Self::Extractor,
+    > {
+        RouteMatch::Matched {
+            request,
+            request_predicates: Arc::clone(&self.request_predicates),
+            response_predicates: Arc::clone(&self.response_predicates),
+            extractors: Arc::clone(&self.extractors),
+            policy: self.policy.clone(),
+        }
     }
 }
 

--- a/hitbox-configuration/src/error.rs
+++ b/hitbox-configuration/src/error.rs
@@ -46,6 +46,14 @@ pub enum ConfigError {
     /// Empty path list in 'in' operation
     #[error("Path 'in' operation requires at least one pattern")]
     EmptyPathList,
+
+    /// Inline endpoint fields and routes were both provided.
+    #[error("Cannot mix inline endpoint fields with 'routes'; choose one configuration mode")]
+    MixedRouteAndInlineConfig,
+
+    /// Multiple route configs used where a single endpoint was expected.
+    #[error("Multiple route configurations found ({0}); use into_routed_endpoint()")]
+    MultipleRouteConfigurations(usize),
 }
 
 impl From<http::method::InvalidMethod> for ConfigError {

--- a/hitbox-configuration/src/lib.rs
+++ b/hitbox-configuration/src/lib.rs
@@ -11,8 +11,9 @@ pub mod predicates;
 pub mod types;
 
 pub use backend::Backend;
-pub use config::ConfigEndpoint;
+pub use config::{ConfigEndpoint, ConfigRoute};
 pub use endpoint::{
     Endpoint, EndpointBuilder, RequestExtractor, RequestPredicate, ResponsePredicate,
+    RoutedEndpoint,
 };
 pub use error::{ConfigError, parse_config};

--- a/hitbox-configuration/tests/test_routes.rs
+++ b/hitbox-configuration/tests/test_routes.rs
@@ -1,0 +1,136 @@
+use bytes::Bytes;
+use hitbox::{CacheConfigRouter, RouteMatch};
+use hitbox_configuration::{ConfigEndpoint, ConfigError};
+use hitbox_http::{BufferedBody, CacheableHttpRequest};
+use http::Request as HttpRequest;
+use http_body_util::Empty;
+use std::time::Duration;
+
+#[test]
+fn test_multi_route_config_deserializes_and_builds() {
+    let yaml = r"
+routes:
+  - request:
+      - Method: GET
+    response: []
+    extractors: []
+    policy:
+      Enabled:
+        ttl: 11s
+  - request:
+      - Method: POST
+    response: []
+    extractors: []
+    policy:
+      Enabled:
+        ttl: 22s
+";
+
+    let endpoint: ConfigEndpoint = serde_saphyr::from_str(yaml).unwrap();
+    let routed = endpoint
+        .into_routed_endpoint::<Empty<Bytes>, Empty<Bytes>>()
+        .unwrap();
+
+    assert_eq!(routed.len(), 2);
+}
+
+#[tokio::test]
+async fn test_multi_route_first_match_selected() {
+    let yaml = r"
+routes:
+  - request:
+      - Method: GET
+    response: []
+    extractors: []
+    policy:
+      Enabled:
+        ttl: 11s
+  - request:
+      - Method: GET
+    response: []
+    extractors: []
+    policy:
+      Enabled:
+        ttl: 22s
+";
+
+    let endpoint: ConfigEndpoint = serde_saphyr::from_str(yaml).unwrap();
+    let routed = endpoint
+        .into_routed_endpoint::<Empty<Bytes>, Empty<Bytes>>()
+        .unwrap();
+
+    let request = CacheableHttpRequest::from_request(
+        HttpRequest::builder()
+            .method("GET")
+            .body(BufferedBody::Passthrough(Empty::<Bytes>::new()))
+            .unwrap(),
+    );
+
+    match routed.route(request).await {
+        RouteMatch::Matched { policy, .. } => {
+            let expected = hitbox::policy::PolicyConfig::builder()
+                .ttl(Duration::from_secs(11))
+                .build();
+            assert_eq!(policy, expected);
+        }
+        RouteMatch::Miss(_) => panic!("expected route match"),
+    }
+}
+
+#[test]
+fn test_into_endpoint_rejects_multiple_routes() {
+    let yaml = r"
+routes:
+  - request:
+      - Method: GET
+    response: []
+    extractors: []
+    policy:
+      Enabled:
+        ttl: 11s
+  - request:
+      - Method: POST
+    response: []
+    extractors: []
+    policy:
+      Enabled:
+        ttl: 22s
+";
+
+    let endpoint: ConfigEndpoint = serde_saphyr::from_str(yaml).unwrap();
+    let result = endpoint.into_endpoint::<Empty<Bytes>, Empty<Bytes>>();
+
+    assert!(matches!(
+        result,
+        Err(ConfigError::MultipleRouteConfigurations(2))
+    ));
+}
+
+#[test]
+fn test_into_routed_endpoint_rejects_mixed_inline_and_routes() {
+    let yaml = r"
+request:
+  - Method: GET
+response: []
+extractors: []
+policy:
+  Enabled:
+    ttl: 5s
+routes:
+  - request:
+      - Method: GET
+    response: []
+    extractors: []
+    policy:
+      Enabled:
+        ttl: 11s
+";
+
+    let endpoint: ConfigEndpoint = serde_saphyr::from_str(yaml).unwrap();
+    let result = endpoint.into_routed_endpoint::<Empty<Bytes>, Empty<Bytes>>();
+
+    assert!(matches!(
+        result,
+        Err(ConfigError::MixedRouteAndInlineConfig)
+    ));
+}

--- a/hitbox-reqwest/src/lib.rs
+++ b/hitbox-reqwest/src/lib.rs
@@ -16,7 +16,7 @@ pub use hitbox_http::{
 pub use reqwest::Body as ReqwestBody;
 
 // Re-export common types
-pub use hitbox::config::CacheConfig;
+pub use hitbox::config::{CacheConfig, CacheConfigRouter, MultiConfig, RouteMatch};
 pub use hitbox::policy::PolicyConfig;
 pub use hitbox::{Config, ConfigBuilder};
 pub use hitbox_core::DisabledOffload;

--- a/hitbox-reqwest/src/middleware.rs
+++ b/hitbox-reqwest/src/middleware.rs
@@ -9,12 +9,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use hitbox::CacheContext;
 use hitbox::CacheStatusExt;
 use hitbox::backend::CacheBackend;
 use hitbox::concurrency::{ConcurrencyManager, NoopConcurrencyManager};
-use hitbox::config::CacheConfig;
+use hitbox::config::{CacheConfigRouter, RouteMatch};
 use hitbox::fsm::CacheFuture;
-use hitbox_core::DisabledOffload;
+use hitbox_core::{DisabledOffload, Upstream};
 use hitbox_http::{
     BufferedBody, CacheableHttpRequest, CacheableHttpResponse, DEFAULT_CACHE_STATUS_HEADER,
 };
@@ -95,14 +96,10 @@ where
 impl<B, C, CM> Middleware for CacheMiddleware<B, C, CM>
 where
     B: CacheBackend + Send + Sync + 'static,
-    C: CacheConfig<CacheableHttpRequest<reqwest::Body>, CacheableHttpResponse<reqwest::Body>>
-        + Clone
+    C: CacheConfigRouter<CacheableHttpRequest<reqwest::Body>, CacheableHttpResponse<reqwest::Body>>
         + Send
         + Sync
         + 'static,
-    C::RequestPredicate: Clone + Send + Sync + 'static,
-    C::ResponsePredicate: Clone + Send + Sync + 'static,
-    C::Extractor: Clone + Send + Sync + 'static,
     CM: ConcurrencyManager<Result<CacheableHttpResponse<reqwest::Body>>>
         + Clone
         + Send
@@ -125,36 +122,47 @@ where
         let buffered_request = http::Request::from_parts(parts, BufferedBody::Passthrough(body));
         let cacheable_req = CacheableHttpRequest::from_request(buffered_request);
 
-        // Create upstream wrapper
-        let upstream = ReqwestUpstream::new(next.clone(), extensions.clone());
+        let (response, cache_context) = match self.configuration.route(cacheable_req).await {
+            RouteMatch::Matched {
+                request,
+                request_predicates,
+                response_predicates,
+                extractors,
+                policy,
+            } => {
+                // Create CacheFuture with DisabledOffload (no background revalidation)
+                // This allows us to use non-'static lifetimes
+                let cache_future: CacheFuture<
+                    '_,
+                    B,
+                    CacheableHttpRequest<reqwest::Body>,
+                    Result<CacheableHttpResponse<reqwest::Body>>,
+                    ReqwestUpstream<'_>,
+                    C::RequestPredicate,
+                    C::ResponsePredicate,
+                    C::Extractor,
+                    CM,
+                    DisabledOffload,
+                > = CacheFuture::new(
+                    self.backend.clone(),
+                    request,
+                    ReqwestUpstream::new(next.clone(), extensions.clone()),
+                    request_predicates,
+                    response_predicates,
+                    extractors,
+                    Arc::new(policy),
+                    DisabledOffload,
+                    self.concurrency_manager.clone(),
+                );
 
-        // Create CacheFuture with DisabledOffload (no background revalidation)
-        // This allows us to use non-'static lifetimes
-        let cache_future: CacheFuture<
-            '_,
-            B,
-            CacheableHttpRequest<reqwest::Body>,
-            Result<CacheableHttpResponse<reqwest::Body>>,
-            ReqwestUpstream<'_>,
-            C::RequestPredicate,
-            C::ResponsePredicate,
-            C::Extractor,
-            CM,
-            DisabledOffload,
-        > = CacheFuture::new(
-            self.backend.clone(),
-            cacheable_req,
-            upstream,
-            self.configuration.request_predicates(),
-            self.configuration.response_predicates(),
-            self.configuration.extractors(),
-            Arc::new(self.configuration.policy().clone()),
-            DisabledOffload,
-            self.concurrency_manager.clone(),
-        );
-
-        // Execute cache future
-        let (response, cache_context) = cache_future.await;
+                cache_future.await
+            }
+            RouteMatch::Miss(request) => {
+                let mut upstream = ReqwestUpstream::new(next.clone(), extensions.clone());
+                let response = upstream.call(request).await;
+                (response, CacheContext::default())
+            }
+        };
 
         // Convert CacheableHttpResponse back to reqwest::Response
         let mut cacheable_response = response?;

--- a/hitbox-tower/src/lib.rs
+++ b/hitbox-tower/src/lib.rs
@@ -11,7 +11,7 @@ pub mod service;
 pub mod upstream;
 
 pub use ::http::{Method, StatusCode};
-pub use hitbox::config::CacheConfig;
+pub use hitbox::config::{CacheConfig, CacheConfigRouter, MultiConfig, RouteMatch};
 pub use hitbox::{Config, ConfigBuilder};
 pub use hitbox_http::DEFAULT_CACHE_STATUS_HEADER;
 pub use layer::{Cache, CacheBuilder, NotSet};

--- a/hitbox-tower/src/service.rs
+++ b/hitbox-tower/src/service.rs
@@ -4,12 +4,12 @@
 //! `Service` that performs the actual caching logic. Users typically don't construct
 //! this directly — it's created by the [`Cache`](crate::Cache) layer.
 
-use hitbox::concurrency::ConcurrencyManager;
-use hitbox::config::CacheConfig;
-use hitbox_core::{DisabledOffload, Offload};
-use std::sync::Arc;
+use std::{future::Future, pin::Pin, sync::Arc};
 
-use hitbox::{backend::CacheBackend, fsm::CacheFuture};
+use hitbox::concurrency::ConcurrencyManager;
+use hitbox::config::{CacheConfigRouter, RouteMatch};
+use hitbox::{CacheContext, backend::CacheBackend, fsm::CacheFuture};
+use hitbox_core::{DisabledOffload, Offload, Upstream};
 use hitbox_http::{BufferedBody, CacheableHttpRequest, CacheableHttpResponse};
 use http::header::HeaderName;
 use http::{Request, Response};
@@ -104,9 +104,13 @@ where
         + 'static,
     B: CacheBackend + Clone + Send + Sync + 'static,
     S::Future: Send,
-    C: CacheConfig<CacheableHttpRequest<ReqBody>, CacheableHttpResponse<ResBody>>,
+    C: CacheConfigRouter<CacheableHttpRequest<ReqBody>, CacheableHttpResponse<ResBody>>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
     CM: ConcurrencyManager<Result<CacheableHttpResponse<ResBody>, S::Error>> + Clone + 'static,
-    O: Offload<'static> + Clone,
+    O: Offload<'static> + Clone + 'static,
     ReqBody: HttpBody + Send + 'static,
     ReqBody::Error: Send,
     ResBody: HttpBody + Send + 'static,
@@ -117,17 +121,15 @@ where
     type Response = Response<BufferedBody<ResBody>>;
     type Error = S::Error;
     type Future = CacheServiceFuture<
-        CacheFuture<
-            'static,
-            B,
-            CacheableHttpRequest<ReqBody>,
-            Result<CacheableHttpResponse<ResBody>, S::Error>,
-            TowerUpstream<S, ReqBody, ResBody>,
-            C::RequestPredicate,
-            C::ResponsePredicate,
-            C::Extractor,
-            CM,
-            O,
+        Pin<
+            Box<
+                dyn Future<
+                        Output = (
+                            Result<CacheableHttpResponse<ResBody>, S::Error>,
+                            CacheContext,
+                        ),
+                    > + Send,
+            >,
         >,
         ResBody,
         S::Error,
@@ -141,30 +143,49 @@ where
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        let configuration = &self.configuration;
-
         // Convert incoming Request<ReqBody> to CacheableHttpRequest<ReqBody>
         let (parts, body) = req.into_parts();
         let buffered_request = Request::from_parts(parts, BufferedBody::Passthrough(body));
         let cacheable_req = CacheableHttpRequest::from_request(buffered_request);
 
-        // Create upstream adapter that handles Tower service calls
-        let upstream = TowerUpstream::new(self.upstream.clone());
+        let backend = self.backend.clone();
+        let configuration = self.configuration.clone();
+        let offload = self.offload.clone();
+        let concurrency_manager = self.concurrency_manager.clone();
+        let upstream = self.upstream.clone();
 
-        // Create CacheFuture with cacheable types only
-        let cache_future = CacheFuture::new(
-            self.backend.clone(),
-            cacheable_req,
-            upstream,
-            configuration.request_predicates(),
-            configuration.response_predicates(),
-            configuration.extractors(),
-            Arc::new(configuration.policy().clone()),
-            self.offload.clone(),
-            self.concurrency_manager.clone(),
-        );
+        let future = Box::pin(async move {
+            match configuration.route(cacheable_req).await {
+                RouteMatch::Matched {
+                    request,
+                    request_predicates,
+                    response_predicates,
+                    extractors,
+                    policy,
+                } => {
+                    let upstream = TowerUpstream::new(upstream);
+                    CacheFuture::new(
+                        backend,
+                        request,
+                        upstream,
+                        request_predicates,
+                        response_predicates,
+                        extractors,
+                        Arc::new(policy),
+                        offload,
+                        concurrency_manager,
+                    )
+                    .await
+                }
+                RouteMatch::Miss(request) => {
+                    let mut upstream = TowerUpstream::new(upstream);
+                    let response = upstream.call(request).await;
+                    (response, CacheContext::default())
+                }
+            }
+        });
 
         // Wrap in CacheServiceFuture to add cache headers
-        CacheServiceFuture::new(cache_future, self.cache_status_header.clone())
+        CacheServiceFuture::new(future, self.cache_status_header.clone())
     }
 }

--- a/hitbox/src/config.rs
+++ b/hitbox/src/config.rs
@@ -5,9 +5,11 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
+
 use crate::Extractor;
 use crate::policy::PolicyConfig;
-use crate::predicate::Predicate;
+use crate::predicate::{Predicate, PredicateResult};
 
 /// Boxed predicate for dynamic dispatch.
 pub type BoxPredicate<R> = Box<dyn Predicate<Subject = R> + Send + Sync>;
@@ -35,6 +37,202 @@ pub trait CacheConfig<Req, Res> {
     fn extractors(&self) -> Self::Extractor;
     /// Returns TTL and behavior policy for cached entries.
     fn policy(&self) -> &PolicyConfig;
+}
+
+/// Route selection result for multi-configuration cache layers.
+#[derive(Debug)]
+pub enum RouteMatch<Req, ReqPred, ResPred, Ext> {
+    /// A configuration matched this request.
+    Matched {
+        /// Request value after predicate evaluation.
+        request: Req,
+        /// Request predicates for the selected configuration.
+        request_predicates: ReqPred,
+        /// Response predicates for the selected configuration.
+        response_predicates: ResPred,
+        /// Cache key extractors for the selected configuration.
+        extractors: Ext,
+        /// Cache policy for the selected configuration.
+        policy: PolicyConfig,
+    },
+    /// No configuration matched this request.
+    Miss(Req),
+}
+
+/// Trait for selecting cache configuration per request.
+///
+/// This supports both single-config and multi-config cache layers.
+#[async_trait]
+pub trait CacheConfigRouter<Req, Res>: Send + Sync {
+    /// Predicate type for filtering requests.
+    type RequestPredicate: Predicate<Subject = Req> + Send + Sync + 'static;
+    /// Predicate type for filtering responses.
+    type ResponsePredicate: Predicate<Subject = Res> + Send + Sync + 'static;
+    /// Extractor type for generating cache keys.
+    type Extractor: Extractor<Subject = Req> + Send + Sync + 'static;
+
+    /// Selects the configuration to use for a request.
+    async fn route(
+        &self,
+        request: Req,
+    ) -> RouteMatch<Req, Self::RequestPredicate, Self::ResponsePredicate, Self::Extractor>;
+}
+
+/// Multi-configuration container for a single cache layer.
+///
+/// Configurations are evaluated in order. The first request predicate that
+/// returns `Cacheable` is selected.
+#[derive(Debug, Clone, Default)]
+pub struct MultiConfig<C> {
+    configs: Vec<C>,
+}
+
+impl<C> MultiConfig<C> {
+    /// Creates a multi-config container from an ordered list.
+    pub fn new(configs: Vec<C>) -> Self {
+        Self { configs }
+    }
+
+    /// Adds a configuration to the end of the routing list.
+    pub fn push(&mut self, config: C) {
+        self.configs.push(config);
+    }
+
+    /// Returns the ordered configurations.
+    pub fn configs(&self) -> &[C] {
+        &self.configs
+    }
+
+    /// Number of configurations.
+    pub fn len(&self) -> usize {
+        self.configs.len()
+    }
+
+    /// Returns true when no configurations are present.
+    pub fn is_empty(&self) -> bool {
+        self.configs.is_empty()
+    }
+
+    /// Consumes the container and returns the ordered configurations.
+    pub fn into_configs(self) -> Vec<C> {
+        self.configs
+    }
+}
+
+#[async_trait]
+impl<Req, Res, C> CacheConfigRouter<Req, Res> for MultiConfig<C>
+where
+    Req: Send + 'static,
+    Res: Send + 'static,
+    C: CacheConfig<Req, Res> + Send + Sync,
+{
+    type RequestPredicate = C::RequestPredicate;
+    type ResponsePredicate = C::ResponsePredicate;
+    type Extractor = C::Extractor;
+
+    async fn route(
+        &self,
+        request: Req,
+    ) -> RouteMatch<Req, Self::RequestPredicate, Self::ResponsePredicate, Self::Extractor> {
+        let mut request = request;
+
+        for config in &self.configs {
+            let request_predicates = config.request_predicates();
+            match request_predicates.check(request).await {
+                PredicateResult::Cacheable(request) => {
+                    return RouteMatch::Matched {
+                        request,
+                        request_predicates,
+                        response_predicates: config.response_predicates(),
+                        extractors: config.extractors(),
+                        policy: config.policy().clone(),
+                    };
+                }
+                PredicateResult::NonCacheable(next_request) => {
+                    request = next_request;
+                }
+            }
+        }
+
+        RouteMatch::Miss(request)
+    }
+}
+
+#[async_trait]
+impl<Req, Res, ReqPred, ResPred, Ext> CacheConfigRouter<Req, Res> for Config<ReqPred, ResPred, Ext>
+where
+    Req: Send + 'static,
+    Res: Send + 'static,
+    ReqPred: Predicate<Subject = Req> + Send + Sync + 'static,
+    ResPred: Predicate<Subject = Res> + Send + Sync + 'static,
+    Ext: Extractor<Subject = Req> + Send + Sync + 'static,
+{
+    type RequestPredicate = Arc<ReqPred>;
+    type ResponsePredicate = Arc<ResPred>;
+    type Extractor = Arc<Ext>;
+
+    async fn route(
+        &self,
+        request: Req,
+    ) -> RouteMatch<Req, Self::RequestPredicate, Self::ResponsePredicate, Self::Extractor> {
+        RouteMatch::Matched {
+            request,
+            request_predicates: Arc::clone(&self.request_predicate),
+            response_predicates: Arc::clone(&self.response_predicate),
+            extractors: Arc::clone(&self.extractor),
+            policy: self.policy.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl<Req, Res, T> CacheConfigRouter<Req, Res> for Arc<T>
+where
+    Req: Send + 'static,
+    Res: Send + 'static,
+    T: CacheConfig<Req, Res> + Send + Sync + ?Sized,
+{
+    type RequestPredicate = T::RequestPredicate;
+    type ResponsePredicate = T::ResponsePredicate;
+    type Extractor = T::Extractor;
+
+    async fn route(
+        &self,
+        request: Req,
+    ) -> RouteMatch<Req, Self::RequestPredicate, Self::ResponsePredicate, Self::Extractor> {
+        RouteMatch::Matched {
+            request,
+            request_predicates: self.as_ref().request_predicates(),
+            response_predicates: self.as_ref().response_predicates(),
+            extractors: self.as_ref().extractors(),
+            policy: self.as_ref().policy().clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl<Req, Res, T> CacheConfigRouter<Req, Res> for Box<T>
+where
+    Req: Send + 'static,
+    Res: Send + 'static,
+    T: CacheConfig<Req, Res> + Send + Sync + ?Sized,
+{
+    type RequestPredicate = T::RequestPredicate;
+    type ResponsePredicate = T::ResponsePredicate;
+    type Extractor = T::Extractor;
+
+    async fn route(
+        &self,
+        request: Req,
+    ) -> RouteMatch<Req, Self::RequestPredicate, Self::ResponsePredicate, Self::Extractor> {
+        RouteMatch::Matched {
+            request,
+            request_predicates: self.as_ref().request_predicates(),
+            response_predicates: self.as_ref().response_predicates(),
+            extractors: self.as_ref().extractors(),
+            policy: self.as_ref().policy().clone(),
+        }
+    }
 }
 
 /// Generic cache configuration.
@@ -253,5 +451,145 @@ where
 
     fn policy(&self) -> &PolicyConfig {
         self.as_ref().policy()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+
+    use crate::{Extractor, KeyParts, policy::PolicyConfig, predicate::PredicateResult};
+
+    use super::{CacheConfigRouter, Config, MultiConfig, RouteMatch};
+
+    #[derive(Clone)]
+    struct MatchRequest {
+        expected: u32,
+    }
+
+    #[async_trait]
+    impl crate::Predicate for MatchRequest {
+        type Subject = u32;
+
+        async fn check(&self, subject: Self::Subject) -> PredicateResult<Self::Subject> {
+            if subject == self.expected {
+                PredicateResult::Cacheable(subject)
+            } else {
+                PredicateResult::NonCacheable(subject)
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct AlwaysResponse;
+
+    #[async_trait]
+    impl crate::Predicate for AlwaysResponse {
+        type Subject = u32;
+
+        async fn check(&self, subject: Self::Subject) -> PredicateResult<Self::Subject> {
+            PredicateResult::Cacheable(subject)
+        }
+    }
+
+    #[derive(Clone)]
+    struct IdentityExtractor;
+
+    #[async_trait]
+    impl Extractor for IdentityExtractor {
+        type Subject = u32;
+
+        async fn get(&self, subject: Self::Subject) -> KeyParts<Self::Subject> {
+            KeyParts::new(subject)
+        }
+    }
+
+    #[tokio::test]
+    async fn single_config_router_always_matches() {
+        let policy = PolicyConfig::disabled();
+        let config = Config::builder()
+            .request_predicate(MatchRequest { expected: 7 })
+            .response_predicate(AlwaysResponse)
+            .extractor(IdentityExtractor)
+            .policy(policy.clone())
+            .build();
+
+        let route = config.route(42).await;
+
+        match route {
+            RouteMatch::Matched {
+                request,
+                policy: selected_policy,
+                ..
+            } => {
+                assert_eq!(request, 42);
+                assert_eq!(selected_policy, policy);
+            }
+            RouteMatch::Miss(_) => panic!("single config should always route"),
+        }
+    }
+
+    #[tokio::test]
+    async fn multi_config_uses_first_matching_route() {
+        let first_policy = PolicyConfig::builder()
+            .ttl(std::time::Duration::from_secs(11))
+            .build();
+        let second_policy = PolicyConfig::builder()
+            .ttl(std::time::Duration::from_secs(22))
+            .build();
+
+        let first = Config::builder()
+            .request_predicate(MatchRequest { expected: 1 })
+            .response_predicate(AlwaysResponse)
+            .extractor(IdentityExtractor)
+            .policy(first_policy.clone())
+            .build();
+
+        let second = Config::builder()
+            .request_predicate(MatchRequest { expected: 1 })
+            .response_predicate(AlwaysResponse)
+            .extractor(IdentityExtractor)
+            .policy(second_policy)
+            .build();
+
+        let routing = MultiConfig::new(vec![first, second]);
+
+        let route = routing.route(1).await;
+
+        match route {
+            RouteMatch::Matched {
+                request,
+                policy: selected_policy,
+                ..
+            } => {
+                assert_eq!(request, 1);
+                assert_eq!(selected_policy, first_policy);
+            }
+            RouteMatch::Miss(_) => panic!("expected a matched route"),
+        }
+    }
+
+    #[tokio::test]
+    async fn multi_config_returns_miss_when_nothing_matches() {
+        let route_one = Config::builder()
+            .request_predicate(MatchRequest { expected: 1 })
+            .response_predicate(AlwaysResponse)
+            .extractor(IdentityExtractor)
+            .build();
+
+        let route_two = Config::builder()
+            .request_predicate(MatchRequest { expected: 2 })
+            .response_predicate(AlwaysResponse)
+            .extractor(IdentityExtractor)
+            .build();
+
+        let routing = MultiConfig::new(vec![route_one, route_two]);
+
+        let route = routing.route(9).await;
+
+        match route {
+            RouteMatch::Miss(request) => assert_eq!(request, 9),
+            RouteMatch::Matched { .. } => panic!("expected route miss"),
+        }
     }
 }

--- a/hitbox/src/lib.rs
+++ b/hitbox/src/lib.rs
@@ -68,7 +68,9 @@ pub mod context;
 /// the [`OffloadManager`](offload::OffloadManager) for handling these background tasks.
 pub mod offload;
 
-pub use config::{CacheConfig, Config, ConfigBuilder, NotSet};
+pub use config::{
+    CacheConfig, CacheConfigRouter, Config, ConfigBuilder, MultiConfig, NotSet, RouteMatch,
+};
 pub use context::{BoxContext, CacheContext, CacheStatus, CacheStatusExt, Context, ResponseSource};
 
 /// Policy configuration for cache behavior.


### PR DESCRIPTION
Summary
- add support for multiple predicate/extractor/policy configurations per `Cache` layer
- ensure routing layer evaluates request predicates so the first match handles the request via the existing `CacheFuture`
- unblock hitboxd and hitbox-configuration by enabling multi-config routing behavior

Testing
- Not run