### PR TITLE
fix(configuration): remove redundant Arc::clone in Endpoint::clone

### DIFF
--- a/hitbox-configuration/CHANGELOG.md
+++ b/hitbox-configuration/CHANGELOG.md
@@ -7,3 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Initial release
+
+### Fixed
+- Remove redundant double `Arc::clone` in `Endpoint::clone` for the `extractors` field ([#214](https://github.com/hit-box/hitbox/issues/214))

--- a/hitbox-configuration/src/endpoint.rs
+++ b/hitbox-configuration/src/endpoint.rs
@@ -55,7 +55,7 @@ where
         Self {
             request_predicates: Arc::clone(&self.request_predicates),
             response_predicates: Arc::clone(&self.response_predicates),
-            extractors: Arc::clone(&self.extractors.clone()),
+            extractors: Arc::clone(&self.extractors),
             policy: self.policy.clone(),
         }
     }


### PR DESCRIPTION
## Summary
- Removed redundant `.clone()` call in `Endpoint::clone()` impl at `hitbox-configuration/src/endpoint.rs:58`
- `Arc::clone(&self.extractors.clone())` performed an unnecessary intermediate `Arc` clone — simplified to `Arc::clone(&self.extractors)`

Closes #214