### PR TITLE
fix(feoxdb): eliminate TOCTOU race in remove

### DIFF
--- a/hitbox-feoxdb/CHANGELOG.md
+++ b/hitbox-feoxdb/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Eliminate TOCTOU race in `remove` by using a single atomic `delete` call ([#216](https://github.com/hit-box/hitbox/issues/216))
+
 ## [0.2.0] - 2026-01-27
 ### Added
 - Initial release

--- a/hitbox-feoxdb/src/backend.rs
+++ b/hitbox-feoxdb/src/backend.rs
@@ -358,17 +358,10 @@ where
         let key_bytes = encode_to_vec(key, bincode_config())
             .map_err(|e| BackendError::InternalError(Box::new(e)))?;
 
-        tokio::task::spawn_blocking(move || {
-            let exists = store.contains_key(&key_bytes);
-
-            if exists {
-                store
-                    .delete(&key_bytes)
-                    .map_err(|e| BackendError::InternalError(Box::new(e)))?;
-                Ok(DeleteStatus::Deleted(1))
-            } else {
-                Ok(DeleteStatus::Missing)
-            }
+        tokio::task::spawn_blocking(move || match store.delete(&key_bytes) {
+            Ok(()) => Ok(DeleteStatus::Deleted(1)),
+            Err(FeoxError::KeyNotFound) => Ok(DeleteStatus::Missing),
+            Err(e) => Err(BackendError::InternalError(Box::new(e))),
         })
         .await
         .map_err(|e| BackendError::InternalError(Box::new(e)))?


### PR DESCRIPTION
## Summary
- Replaced `contains_key()` + `delete()` (two separate operations) with a single `delete()` call and match on the result
- `FeoxStore::delete` already returns `Err(KeyNotFound)` when the key is absent, giving us the exists/missing distinction atomically

Closes #216