### PR TITLE
refactor: make CacheConfiguration trate in a single style

### DIFF
--- a/hitbox-configuration/src/config.rs
+++ b/hitbox-configuration/src/config.rs
@@ -26,7 +26,7 @@ pub struct ConfigEndpoint {
     pub response: MaybeUndefined<Response>,
     #[serde(default)]
     pub extractors: MaybeUndefined<Vec<Extractor>>,
-    pub policy: PolicyConfig,
+    pub policy: Arc<PolicyConfig>,
 }
 
 impl ConfigEndpoint {

--- a/hitbox-configuration/src/endpoint.rs
+++ b/hitbox-configuration/src/endpoint.rs
@@ -28,7 +28,7 @@ where
     pub request_predicates: ArcRequestPredicate<ReqBody>,
     pub response_predicates: ArcResponsePredicate<ResBody>,
     pub extractors: ArcRequestExtractor<ReqBody>,
-    pub policy: PolicyConfig,
+    pub policy: Arc<PolicyConfig>,
 }
 
 impl<ReqBody, ResBody> Debug for Endpoint<ReqBody, ResBody>
@@ -56,7 +56,7 @@ where
             request_predicates: Arc::clone(&self.request_predicates),
             response_predicates: Arc::clone(&self.response_predicates),
             extractors: Arc::clone(&self.extractors),
-            policy: self.policy.clone(),
+            policy: Arc::clone(&self.policy),
         }
     }
 }
@@ -103,8 +103,8 @@ where
         Arc::clone(&self.extractors)
     }
 
-    fn policy(&self) -> &PolicyConfig {
-        &self.policy
+    fn policy(&self) -> Arc<PolicyConfig> {
+        Arc::clone(&self.policy)
     }
 }
 
@@ -128,7 +128,7 @@ where
     request_predicates: Option<ArcRequestPredicate<ReqBody>>,
     response_predicates: Option<ArcResponsePredicate<ResBody>>,
     extractors: Option<ArcRequestExtractor<ReqBody>>,
-    policy: PolicyConfig,
+    policy: Arc<PolicyConfig>,
 }
 
 impl<ReqBody, ResBody> EndpointBuilder<ReqBody, ResBody>
@@ -142,7 +142,7 @@ where
             request_predicates: None,
             response_predicates: None,
             extractors: None,
-            policy: PolicyConfig::default(),
+            policy: Arc::new(PolicyConfig::default()),
         }
     }
 
@@ -180,7 +180,7 @@ where
     }
 
     /// Set the cache policy.
-    pub fn policy(self, policy: PolicyConfig) -> Self {
+    pub fn policy(self, policy: Arc<PolicyConfig>) -> Self {
         Self { policy, ..self }
     }
 

--- a/hitbox-derive/src/cached/generator.rs
+++ b/hitbox-derive/src/cached/generator.rs
@@ -243,11 +243,11 @@ impl ToTokens for CallImplPolicy<'_> {
 
         tokens.extend(quote! {
             impl #impl_generics #call_name #type_generics_no_policy {
-                pub fn policy(self, policy: hitbox::policy::PolicyConfig) -> #call_name #type_generics_with_policy {
+                pub fn policy(self, policy: std::sync::Arc<hitbox::policy::PolicyConfig>) -> #call_name #type_generics_with_policy {
                     #call_name {
                         args: self.args,
                         backend: self.backend,
-                        policy: hitbox_fn::WithPolicy(std::sync::Arc::new(policy)),
+                        policy: hitbox_fn::WithPolicy(policy),
                         _context: std::marker::PhantomData,
                     }
                 }

--- a/hitbox-fn/src/cache.rs
+++ b/hitbox-fn/src/cache.rs
@@ -229,10 +229,10 @@ impl<B, CM, O> CacheBuilder<B, NoPolicy, CM, O> {
     /// let builder = Cache::builder()
     ///     .policy(PolicyConfig::builder().ttl(Duration::from_secs(60)).build());
     /// ```
-    pub fn policy(self, policy: PolicyConfig) -> CacheBuilder<B, WithPolicy, CM, O> {
+    pub fn policy(self, policy: Arc<PolicyConfig>) -> CacheBuilder<B, WithPolicy, CM, O> {
         CacheBuilder {
             backend: self.backend,
-            policy: WithPolicy(Arc::new(policy)),
+            policy: WithPolicy(policy),
             concurrency_manager: self.concurrency_manager,
             offload: self.offload,
         }

--- a/hitbox-fn/tests/cached_macro.rs
+++ b/hitbox-fn/tests/cached_macro.rs
@@ -640,7 +640,7 @@ async fn test_key_zero_args() {
     // Reconstruct a second cache from accessors of the first one
     let cache2 = Cache::builder()
         .backend(SpyBackend::new())
-        .policy(cache.policy().as_ref().clone())
+        .policy(cache.policy().clone())
         .concurrency_manager(cache.concurrency_manager().clone())
         .offload(*cache.offload())
         .build();

--- a/hitbox-reqwest/src/middleware.rs
+++ b/hitbox-reqwest/src/middleware.rs
@@ -148,7 +148,7 @@ where
             self.configuration.request_predicates(),
             self.configuration.response_predicates(),
             self.configuration.extractors(),
-            Arc::new(self.configuration.policy().clone()),
+            self.configuration.policy().clone(),
             DisabledOffload,
             self.concurrency_manager.clone(),
         );

--- a/hitbox-test/benches/cache_future_reference.rs
+++ b/hitbox-test/benches/cache_future_reference.rs
@@ -809,7 +809,7 @@ fn bench_compare_cache_future_hit(c: &mut Criterion) {
         .endpoint
         .into_endpoint::<InnerBody, InnerBody>()
         .expect("Failed to create endpoint");
-    let dyn_policy = Arc::new(endpoint.policy.clone());
+    let dyn_policy = endpoint.policy.clone();
 
     // Pre-populate dynamic cache
     let request = CacheableHttpRequest::from_request(create_reference_request());
@@ -941,7 +941,7 @@ fn bench_compare_cache_future_miss(c: &mut Criterion) {
         .endpoint
         .into_endpoint::<InnerBody, InnerBody>()
         .expect("Failed to create endpoint");
-    let dyn_policy = Arc::new(endpoint.policy.clone());
+    let dyn_policy = endpoint.policy.clone();
     let dyn_backend_arc: Arc<DynBackend> = Arc::new(dyn_backend);
 
     // Use atomic counters for unique request IDs
@@ -1192,7 +1192,7 @@ fn bench_compare_body_cache_future_hit(c: &mut Criterion) {
         .endpoint
         .into_endpoint::<InnerBody, InnerBody>()
         .expect("Failed to create endpoint");
-    let dyn_policy = Arc::new(endpoint.policy.clone());
+    let dyn_policy = endpoint.policy.clone();
 
     // Pre-populate dynamic cache
     let request = CacheableHttpRequest::from_request(create_reference_request());
@@ -1323,7 +1323,7 @@ fn bench_compare_body_cache_future_miss(c: &mut Criterion) {
         .endpoint
         .into_endpoint::<InnerBody, InnerBody>()
         .expect("Failed to create endpoint");
-    let dyn_policy = Arc::new(endpoint.policy.clone());
+    let dyn_policy = endpoint.policy.clone();
     let dyn_backend_arc: Arc<DynBackend> = Arc::new(dyn_backend);
 
     // Use atomic counters for unique request IDs

--- a/hitbox-test/src/core.rs
+++ b/hitbox-test/src/core.rs
@@ -39,7 +39,7 @@ pub struct TestConfig {
     pub request_predicate: Arc<BoxRequestPredicate>,
     pub response_predicate: Arc<BoxResponsePredicate>,
     pub extractor: Arc<BoxExtractor>,
-    pub policy: PolicyConfig,
+    pub policy: Arc<PolicyConfig>,
 }
 
 impl std::fmt::Debug for TestConfig {
@@ -59,7 +59,7 @@ impl Clone for TestConfig {
             request_predicate: Arc::clone(&self.request_predicate),
             response_predicate: Arc::clone(&self.response_predicate),
             extractor: Arc::clone(&self.extractor),
-            policy: self.policy.clone(),
+            policy: Arc::clone(&self.policy),
         }
     }
 }
@@ -75,7 +75,7 @@ impl Default for TestConfig {
             request_predicate: Arc::new(request_predicate),
             response_predicate: Arc::new(response_predicate),
             extractor: Arc::new(extractor),
-            policy: PolicyConfig::default(),
+            policy: Arc::new(PolicyConfig::default()),
         }
     }
 }

--- a/hitbox-test/src/steps/given.rs
+++ b/hitbox-test/src/steps/given.rs
@@ -14,12 +14,13 @@ use serde::{Deserialize, Serialize};
 
 #[given(regex = r"hitbox with policy")]
 fn hitbox_with_policy(world: &mut HitboxWorld, step: &Step) -> Result<(), Error> {
-    let policy = step
-        .docstring_content()
-        .as_deref()
-        .map(serde_saphyr::from_str::<PolicyConfig>)
-        .transpose()?
-        .unwrap_or_default();
+    let policy = Arc::new(
+        step.docstring_content()
+            .as_deref()
+            .map(serde_saphyr::from_str::<PolicyConfig>)
+            .transpose()?
+            .unwrap_or_default(),
+    );
     world.config.policy = policy;
     Ok(())
 }

--- a/hitbox-tower/src/service.rs
+++ b/hitbox-tower/src/service.rs
@@ -159,7 +159,7 @@ where
             configuration.request_predicates(),
             configuration.response_predicates(),
             configuration.extractors(),
-            Arc::new(configuration.policy().clone()),
+            configuration.policy().clone(),
             self.offload.clone(),
             self.concurrency_manager.clone(),
         );

--- a/hitbox/src/config.rs
+++ b/hitbox/src/config.rs
@@ -34,7 +34,7 @@ pub trait CacheConfig<Req, Res> {
     /// Returns extractors that generate cache keys from requests.
     fn extractors(&self) -> Self::Extractor;
     /// Returns TTL and behavior policy for cached entries.
-    fn policy(&self) -> &PolicyConfig;
+    fn policy(&self) -> Arc<PolicyConfig>;
 }
 
 /// Generic cache configuration.
@@ -72,7 +72,7 @@ pub struct Config<ReqPred, ResPred, Ext> {
     request_predicate: Arc<ReqPred>,
     response_predicate: Arc<ResPred>,
     extractor: Arc<Ext>,
-    policy: PolicyConfig,
+    policy: Arc<PolicyConfig>,
 }
 
 impl<ReqPred, ResPred, Ext> Clone for Config<ReqPred, ResPred, Ext> {
@@ -81,7 +81,7 @@ impl<ReqPred, ResPred, Ext> Clone for Config<ReqPred, ResPred, Ext> {
             request_predicate: Arc::clone(&self.request_predicate),
             response_predicate: Arc::clone(&self.response_predicate),
             extractor: Arc::clone(&self.extractor),
-            policy: self.policy.clone(),
+            policy: Arc::clone(&self.policy),
         }
     }
 }
@@ -121,8 +121,8 @@ where
         Arc::clone(&self.extractor)
     }
 
-    fn policy(&self) -> &PolicyConfig {
-        &self.policy
+    fn policy(&self) -> Arc<PolicyConfig> {
+        Arc::clone(&self.policy)
     }
 }
 
@@ -133,7 +133,7 @@ pub struct ConfigBuilder<ReqPred, ResPred, Ext> {
     request_predicate: ReqPred,
     response_predicate: ResPred,
     extractor: Ext,
-    policy: PolicyConfig,
+    policy: Arc<PolicyConfig>,
 }
 
 /// Marker type for unset builder fields.
@@ -157,7 +157,7 @@ impl ConfigBuilder<NotSet, NotSet, NotSet> {
             request_predicate: NotSet,
             response_predicate: NotSet,
             extractor: NotSet,
-            policy: PolicyConfig::default(),
+            policy: Arc::new(PolicyConfig::default()),
         }
     }
 }
@@ -206,7 +206,7 @@ impl<ReqPred, ResPred, Ext> ConfigBuilder<ReqPred, ResPred, Ext> {
     }
 
     /// Sets the cache policy.
-    pub fn policy(self, policy: PolicyConfig) -> Self {
+    pub fn policy(self, policy: Arc<PolicyConfig>) -> Self {
         Self { policy, ..self }
     }
 }
@@ -251,7 +251,7 @@ where
         self.as_ref().extractors()
     }
 
-    fn policy(&self) -> &PolicyConfig {
+    fn policy(&self) -> Arc<PolicyConfig> {
         self.as_ref().policy()
     }
 }

--- a/hitbox/src/policy.rs
+++ b/hitbox/src/policy.rs
@@ -3,6 +3,7 @@
 //! Controls how long data stays fresh, when stale data can be served,
 //! and how concurrent requests are coordinated during cache misses.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use bounded_integer::BoundedU8;
@@ -125,14 +126,14 @@ impl PolicyConfigBuilder {
     }
 
     /// Build the PolicyConfig with enabled caching.
-    pub fn build(self) -> PolicyConfig {
-        PolicyConfig::Enabled(EnabledCacheConfig {
+    pub fn build(self) -> Arc<PolicyConfig> {
+        Arc::new(PolicyConfig::Enabled(EnabledCacheConfig {
             ttl: self.ttl,
             stale: self.stale,
             policy: CacheBehaviorPolicy {
                 stale: self.stale_policy,
             },
             concurrency: self.concurrency,
-        })
+        }))
     }
 }


### PR DESCRIPTION
## Summary
- Change ```policy()``` to return ```Arc<PolicyConfig>```, matching the other methods.

Closes #231.