### PR TITLE
fix(redis): migrate to read_routing_strategy API

### DIFF
--- a/hitbox-redis/CHANGELOG.md
+++ b/hitbox-redis/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump minimum `redis` dependency to 1.2 and migrate from deprecated `ClusterClientBuilder::read_from_replicas()` to `read_routing_strategy(RandomReplicaStrategy)`.
 
 ## [0.2.1] - 2026-02-09
 

--- a/hitbox-redis/Cargo.toml
+++ b/hitbox-redis/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["cache", "async", "cache-backend", "hitbox", "redis"]
 hitbox-backend = { path = "../hitbox-backend", version = "0.2" }
 hitbox = { path = "../hitbox", version = "0.2" }
 log = "0.4"
-redis = { version = "1.0", features = ["tokio-comp", "connection-manager"] }
+redis = { version = "1.2", features = ["tokio-comp", "connection-manager"] }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/hitbox-redis/src/backend.rs
+++ b/hitbox-redis/src/backend.rs
@@ -499,7 +499,9 @@ where
                             config.nodes.iter().map(|s| s.as_str()),
                         );
                         if config.read_from_replicas {
-                            builder = builder.read_from_replicas();
+                            builder = builder.read_routing_strategy(
+                                redis::cluster_read_routing::RandomReplicaStrategy,
+                            );
                         }
                         if let Some(ref username) = self.username {
                             builder = builder.username(username.clone());

--- a/hitbox-test/Cargo.toml
+++ b/hitbox-test/Cargo.toml
@@ -70,8 +70,8 @@ jaq-std = "2.1.0"
 jaq-json = { version = "1.1.0", features = ["serde_json"] }
 serial_test = "3.2"
 tempfile = "3"
-testcontainers = { version = "0.26", default-features = false }
-testcontainers-modules = { version = "0.14", default-features = false, features = ["redis"] }
+testcontainers = { version = "0.27", default-features = false }
+testcontainers-modules = { version = "0.15", default-features = false, features = ["redis"] }
 
 [dependencies.rkyv]
 workspace = true


### PR DESCRIPTION
Replace the deprecated `ClusterClientBuilder::read_from_replicas()` call with `read_routing_strategy(RandomReplicaStrategy)`, introduced in redis 1.2.0. Bump the minimum `redis` dependency to 1.2 so downstream users resolve a version that ships the new API.

Fixes `-D warnings` clippy failures on every open PR once cargo resolves redis 1.2.0 or newer.