### PR TITLE
feat(tags): tag-based cache invalidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ tarpaulin-report.html
 # Local development
 .context/
 docs/
+
+# Coverage artifacts
+*.profraw
+lcov.info

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ chrono = { version = "0.4", default-features = false, features = ["serde"] }
 # Error handling and utilities
 thiserror = "2"
 tracing = { version = "0.1", default-features = false }
-futures = { version = "0.3", default-features = false }
+futures = { version = "0.3", default-features = false, features = ["alloc"] }
 pin-project = "1"
 regex = "1"
 smol_str = { version = "0.3", features = ["serde"] }

--- a/hitbox-backend/src/backend.rs
+++ b/hitbox-backend/src/backend.rs
@@ -25,7 +25,9 @@ use crate::{
 ///
 /// Returns `None` if tags are `None`. Used by backends that store tags
 /// as a separate hash field or payload section.
-pub fn serialize_tags(tags: Option<&hitbox_core::tag::CacheTags>) -> BackendResult<Option<Vec<u8>>> {
+pub fn serialize_tags(
+    tags: Option<&hitbox_core::tag::CacheTags>,
+) -> BackendResult<Option<Vec<u8>>> {
     match tags {
         None => Ok(None),
         Some(tags) => {
@@ -231,7 +233,10 @@ impl Backend for &dyn Backend {
         (*self).invalidate(tag).await
     }
 
-    async fn invalidated(&self, tags: &[CacheTag]) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
+    async fn invalidated(
+        &self,
+        tags: &[CacheTag],
+    ) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
         (*self).invalidated(tags).await
     }
 }
@@ -270,7 +275,10 @@ impl Backend for Box<dyn Backend> {
         (**self).invalidate(tag).await
     }
 
-    async fn invalidated(&self, tags: &[CacheTag]) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
+    async fn invalidated(
+        &self,
+        tags: &[CacheTag],
+    ) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
         (**self).invalidated(tags).await
     }
 }
@@ -309,7 +317,10 @@ impl Backend for Arc<UnsyncBackend> {
         (**self).invalidate(tag).await
     }
 
-    async fn invalidated(&self, tags: &[CacheTag]) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
+    async fn invalidated(
+        &self,
+        tags: &[CacheTag],
+    ) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
         (**self).invalidated(tags).await
     }
 }
@@ -348,7 +359,10 @@ impl Backend for Arc<SyncBackend> {
         (**self).invalidate(tag).await
     }
 
-    async fn invalidated(&self, tags: &[CacheTag]) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
+    async fn invalidated(
+        &self,
+        tags: &[CacheTag],
+    ) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
         (**self).invalidated(tags).await
     }
 }
@@ -505,8 +519,7 @@ pub trait CacheBackend: Backend {
                 value.stale(),
             )
             .with_optional_tags(value.tags().cloned());
-            let result = self.write(key, raw_value)
-                .await;
+            let result = self.write(key, raw_value).await;
             crate::metrics::record_write(backend_label.as_str(), write_timer.elapsed());
 
             match result {

--- a/hitbox-backend/src/backend.rs
+++ b/hitbox-backend/src/backend.rs
@@ -5,13 +5,14 @@
 //! - [`Backend`] - Low-level dyn-compatible trait for raw byte operations
 //! - [`CacheBackend`] - High-level trait with typed operations (automatic via blanket impl)
 
-use std::{future::Future, sync::Arc};
+use std::{collections::HashMap, future::Future, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use chrono::{DateTime, Utc};
 use hitbox_core::{
-    BackendLabel, BoxContext, CacheKey, CacheStatus, CacheValue, Cacheable, CacheableResponse, Raw,
-    ReadMode, ResponseSource,
+    BackendLabel, BoxContext, CacheKey, CacheStatus, CacheTag, CacheValue, Cacheable,
+    CacheableResponse, Raw, ReadMode, ResponseSource,
 };
 
 use crate::{
@@ -19,6 +20,38 @@ use crate::{
     format::{BincodeFormat, Format, FormatExt},
     metrics::Timer,
 };
+
+/// Serialize cache tags to bincode bytes for backend storage.
+///
+/// Returns `None` if tags are `None`. Used by backends that store tags
+/// as a separate hash field or payload section.
+pub fn serialize_tags(tags: Option<&hitbox_core::tag::CacheTags>) -> BackendResult<Option<Vec<u8>>> {
+    match tags {
+        None => Ok(None),
+        Some(tags) => {
+            let bytes = bincode::serde::encode_to_vec(tags, bincode::config::standard())
+                .map_err(|e| BackendError::InternalError(Box::new(e)))?;
+            Ok(Some(bytes))
+        }
+    }
+}
+
+/// Deserialize cache tags from bincode bytes.
+///
+/// Returns `Ok(None)` for empty input or absence of tag data.
+pub fn deserialize_tags(
+    bytes: Option<&[u8]>,
+) -> BackendResult<Option<hitbox_core::tag::CacheTags>> {
+    match bytes {
+        None => Ok(None),
+        Some(bytes) if bytes.is_empty() => Ok(None),
+        Some(bytes) => {
+            let (tags, _) = bincode::serde::decode_from_slice(bytes, bincode::config::standard())
+                .map_err(|e| BackendError::InternalError(Box::new(e)))?;
+            Ok(Some(tags))
+        }
+    }
+}
 
 /// Status of a delete operation.
 #[derive(Debug, PartialEq, Eq)]
@@ -44,6 +77,24 @@ pub type UnsyncBackend = dyn Backend + Send;
 
 /// Type alias for a dynamically dispatched Backend that is Send + Sync.
 pub type SyncBackend = dyn Backend + Send + Sync;
+
+/// Serialized tag invalidation timestamp.
+///
+/// Stored as 8 bytes (i64 little-endian milliseconds since Unix epoch).
+struct TagTimestamp;
+
+impl TagTimestamp {
+    const SIZE: usize = 8;
+
+    fn encode(ts: DateTime<Utc>) -> Bytes {
+        Bytes::from(ts.timestamp_millis().to_le_bytes().to_vec())
+    }
+
+    fn decode(data: &[u8]) -> Option<DateTime<Utc>> {
+        let bytes: [u8; Self::SIZE] = data.try_into().ok()?;
+        DateTime::from_timestamp_millis(i64::from_le_bytes(bytes))
+    }
+}
 
 /// Low-level cache storage trait for raw byte operations.
 ///
@@ -92,6 +143,58 @@ pub trait Backend: Sync + Send {
     fn compressor(&self) -> &dyn Compressor {
         &PassthroughCompressor
     }
+
+    /// Prefix used for tag invalidation keys.
+    ///
+    /// Tag invalidation timestamps are stored as regular cache entries under
+    /// keys with this prefix. Override to customize the namespace.
+    ///
+    /// Default: `"__hitbox_tag"`.
+    fn tag_key_prefix(&self) -> &str {
+        "__hitbox_tag"
+    }
+
+    /// Invalidate all cache entries associated with a tag.
+    ///
+    /// Writes an invalidation timestamp for the given tag. The FSM compares
+    /// this timestamp against entry creation time to determine cache state.
+    ///
+    /// Default implementation stores the timestamp via [`Backend::write`]
+    /// using a key derived from [`Backend::tag_key_prefix`].
+    async fn invalidate(&self, tag: &CacheTag) -> BackendResult<()> {
+        let key = tag.to_cache_key(self.tag_key_prefix());
+        let value = CacheValue::new(TagTimestamp::encode(Utc::now()), None, None);
+        self.write(&key, value).await
+    }
+
+    /// Query invalidation timestamps for the given tags.
+    ///
+    /// Returns a map of tag → invalidation timestamp for tags that have been
+    /// invalidated. Tags that have never been invalidated are absent from the map.
+    ///
+    /// Default implementation reads timestamps via [`Backend::read`]
+    /// using keys derived from [`Backend::tag_key_prefix`].
+    async fn invalidated(
+        &self,
+        tags: &[CacheTag],
+    ) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
+        let prefix = self.tag_key_prefix();
+        use futures::stream::{FuturesUnordered, TryStreamExt};
+
+        tags.iter()
+            .map(|tag| async move {
+                let key = tag.to_cache_key(prefix);
+                let value: BackendResult<Option<CacheValue<Raw>>> = self.read(&key).await;
+                match value? {
+                    Some(v) => Ok(TagTimestamp::decode(v.data()).map(|ts| (tag.clone(), ts))),
+                    None => Ok(None),
+                }
+            })
+            .collect::<FuturesUnordered<_>>()
+            .try_filter_map(|opt| async move { Ok(opt) })
+            .try_collect()
+            .await
+    }
 }
 
 #[async_trait]
@@ -122,6 +225,14 @@ impl Backend for &dyn Backend {
 
     fn compressor(&self) -> &dyn Compressor {
         (*self).compressor()
+    }
+
+    async fn invalidate(&self, tag: &CacheTag) -> BackendResult<()> {
+        (*self).invalidate(tag).await
+    }
+
+    async fn invalidated(&self, tags: &[CacheTag]) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
+        (*self).invalidated(tags).await
     }
 }
 
@@ -154,6 +265,14 @@ impl Backend for Box<dyn Backend> {
     fn compressor(&self) -> &dyn Compressor {
         (**self).compressor()
     }
+
+    async fn invalidate(&self, tag: &CacheTag) -> BackendResult<()> {
+        (**self).invalidate(tag).await
+    }
+
+    async fn invalidated(&self, tags: &[CacheTag]) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
+        (**self).invalidated(tags).await
+    }
 }
 
 #[async_trait]
@@ -185,6 +304,14 @@ impl Backend for Arc<UnsyncBackend> {
     fn compressor(&self) -> &dyn Compressor {
         (**self).compressor()
     }
+
+    async fn invalidate(&self, tag: &CacheTag) -> BackendResult<()> {
+        (**self).invalidate(tag).await
+    }
+
+    async fn invalidated(&self, tags: &[CacheTag]) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
+        (**self).invalidated(tags).await
+    }
 }
 
 #[async_trait]
@@ -215,6 +342,14 @@ impl Backend for Arc<SyncBackend> {
 
     fn compressor(&self) -> &dyn Compressor {
         (**self).compressor()
+    }
+
+    async fn invalidate(&self, tag: &CacheTag) -> BackendResult<()> {
+        (**self).invalidate(tag).await
+    }
+
+    async fn invalidated(&self, tags: &[CacheTag]) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
+        (**self).invalidated(tags).await
     }
 }
 
@@ -297,7 +432,16 @@ pub trait CacheBackend: Backend {
                         )))
                     })?;
 
-                    let cached_value = CacheValue::new(deserialized, meta.expire, meta.stale);
+                    let cached_value = CacheValue::with_created(
+                        deserialized,
+                        meta.created,
+                        meta.expire,
+                        meta.stale,
+                    );
+                    let cached_value = match meta.tags {
+                        Some(tags) => cached_value.with_tags(tags),
+                        None => cached_value,
+                    };
 
                     // Refill L1 if read mode is Refill (data came from L2).
                     // CompositionFormat will create L1-only envelope, so only L1 gets populated.
@@ -354,11 +498,14 @@ pub trait CacheBackend: Backend {
             let compressed_len = compressed_value.len();
 
             let write_timer = Timer::new();
-            let result = self
-                .write(
-                    key,
-                    CacheValue::new(Bytes::from(compressed_value), value.expire(), value.stale()),
-                )
+            let raw_value = CacheValue::with_created(
+                Bytes::from(compressed_value),
+                value.created(),
+                value.expire(),
+                value.stale(),
+            )
+            .with_optional_tags(value.tags().cloned());
+            let result = self.write(key, raw_value)
                 .await;
             crate::metrics::record_write(backend_label.as_str(), write_timer.elapsed());
 

--- a/hitbox-backend/src/composition/compose.rs
+++ b/hitbox-backend/src/composition/compose.rs
@@ -136,6 +136,7 @@ mod tests {
     };
     use async_trait::async_trait;
     use chrono::Utc;
+    use hitbox_core::tag::{CacheTag, TagExtractor};
     use hitbox_core::{
         BoxContext, CacheContext, CacheKey, CachePolicy, CacheValue, CacheableResponse,
         EntityPolicyConfig, Predicate, Raw,
@@ -226,11 +227,16 @@ mod tests {
         type IntoCachedFuture = std::future::Ready<CachePolicy<Self::Cached, Self>>;
         type FromCachedFuture = std::future::Ready<Self>;
 
-        async fn cache_policy<P: Predicate<Subject = Self::Subject> + Send + Sync>(
+        async fn cache_policy<P, TE>(
             self,
             _predicate: P,
+            _tag_extractor: TE,
             _config: &EntityPolicyConfig,
-        ) -> CachePolicy<CacheValue<Self::Cached>, Self> {
+        ) -> (CachePolicy<CacheValue<Self::Cached>, Self>, Vec<CacheTag>)
+        where
+            P: Predicate<Subject = Self::Subject> + Send + Sync,
+            TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
+        {
             unimplemented!()
         }
 

--- a/hitbox-backend/src/composition/compose.rs
+++ b/hitbox-backend/src/composition/compose.rs
@@ -230,7 +230,7 @@ mod tests {
         async fn cache_policy<P, TE>(
             self,
             _predicate: P,
-            _tag_extractor: TE,
+            _tag_extractor: Option<TE>,
             _config: &EntityPolicyConfig,
         ) -> (CachePolicy<CacheValue<Self::Cached>, Self>, Vec<CacheTag>)
         where

--- a/hitbox-backend/src/composition/envelope.rs
+++ b/hitbox-backend/src/composition/envelope.rs
@@ -321,13 +321,14 @@ impl CompositionEnvelope {
         let tags_len = header.tags_len as usize;
 
         // Helper to attach tags to a CacheValue if present.
-        let with_tags_opt = |cv: CacheValue<Raw>, tags_bytes: Option<&[u8]>| -> BackendResult<CacheValue<Raw>> {
-            let tags = crate::deserialize_tags(tags_bytes)?;
-            Ok(match tags {
-                Some(tags) => cv.with_tags(tags),
-                None => cv,
-            })
-        };
+        let with_tags_opt =
+            |cv: CacheValue<Raw>, tags_bytes: Option<&[u8]>| -> BackendResult<CacheValue<Raw>> {
+                let tags = crate::deserialize_tags(tags_bytes)?;
+                Ok(match tags {
+                    Some(tags) => cv.with_tags(tags),
+                    None => cv,
+                })
+            };
 
         match header.discriminant {
             0 => {

--- a/hitbox-backend/src/composition/envelope.rs
+++ b/hitbox-backend/src/composition/envelope.rs
@@ -8,7 +8,7 @@
 //! ## Format Layout
 //!
 //! ```text
-//! [EnvelopeHeader (48 bytes)][L1 data][L2 data (if Both variant)]
+//! [EnvelopeHeader (56 bytes)][L1 data][L2 data (if Both variant)][Tags bincode (if tags_len > 0)]
 //! ```
 //!
 //! ## Performance
@@ -30,20 +30,21 @@ use crate::{BackendError, BackendResult};
 
 /// Fixed-size header for envelope format using repr(C) with bytemuck for safe zero-copy casting.
 ///
-/// Layout (with explicit padding for alignment):
+/// Layout (fields grouped by size to minimize padding):
 /// - discriminant: 1 byte (0=L1, 1=L2, 2=Both)
-/// - _pad1: 3 bytes (explicit padding to align u32)
+/// - _pad1: 3 bytes (align to u32)
 /// - l1_len: 4 bytes (u32 little-endian)
 /// - l2_len: 4 bytes (u32 little-endian)
-/// - _pad2: 4 bytes (explicit padding to align i64)
-/// - expire_secs: 8 bytes (i64 little-endian) - seconds since Unix epoch, 0 if None
+/// - tags_len: 4 bytes (u32 little-endian) - length of bincode tag bytes after data; 0 = no tags
+/// - created_secs: 8 bytes (i64 little-endian) - seconds since Unix epoch
+/// - expire_secs: 8 bytes (i64 little-endian) - 0 if None
+/// - stale_secs: 8 bytes (i64 little-endian) - 0 if None
+/// - created_nanos: 4 bytes (u32 little-endian) - nanoseconds component
 /// - expire_nanos: 4 bytes (u32 little-endian) - nanoseconds component
-/// - _pad3: 4 bytes (explicit padding to align i64)
-/// - stale_secs: 8 bytes (i64 little-endian) - seconds since Unix epoch, 0 if None
 /// - stale_nanos: 4 bytes (u32 little-endian) - nanoseconds component
-/// - _pad4: 4 bytes (explicit padding for struct alignment)
+/// - _pad2: 4 bytes (struct tail alignment)
 ///
-/// Total: 48 bytes (with explicit padding)
+/// Total: 56 bytes
 ///
 /// Padding fields are explicitly defined and zero-initialized to satisfy bytemuck's Pod trait
 /// requirements. This enables safe zero-copy type conversion while maintaining optimal alignment.
@@ -54,19 +55,29 @@ struct EnvelopeHeader {
     _pad1: [u8; 3],
     l1_len: u32,
     l2_len: u32,
-    _pad2: [u8; 4],
+    tags_len: u32, // length of bincode-serialized CacheTags after L1+L2 data; 0 = no tags
+    // i64 fields grouped together (8-byte aligned, no inter-field padding)
+    created_secs: i64,
     expire_secs: i64,
-    expire_nanos: u32,
-    _pad3: [u8; 4],
     stale_secs: i64,
+    // u32 fields grouped together
+    created_nanos: u32,
+    expire_nanos: u32,
     stale_nanos: u32,
-    _pad4: [u8; 4],
+    _pad2: [u8; 4], // struct tail alignment to 8
 }
 
 impl EnvelopeHeader {
     const SIZE: usize = std::mem::size_of::<Self>();
 
-    fn new_l1(l1_len: usize, expire: Option<DateTime<Utc>>, stale: Option<DateTime<Utc>>) -> Self {
+    fn new_l1(
+        l1_len: usize,
+        tags_len: usize,
+        created: DateTime<Utc>,
+        expire: Option<DateTime<Utc>>,
+        stale: Option<DateTime<Utc>>,
+    ) -> Self {
+        let (created_secs, created_nanos) = Self::encode_created(created);
         let (expire_secs, expire_nanos) = Self::encode_timestamp(expire);
         let (stale_secs, stale_nanos) = Self::encode_timestamp(stale);
 
@@ -75,17 +86,25 @@ impl EnvelopeHeader {
             _pad1: [0; 3],
             l1_len: l1_len as u32,
             l2_len: 0,
-            _pad2: [0; 4],
+            tags_len: tags_len as u32,
+            created_secs,
             expire_secs,
-            expire_nanos,
-            _pad3: [0; 4],
             stale_secs,
+            created_nanos,
+            expire_nanos,
             stale_nanos,
-            _pad4: [0; 4],
+            _pad2: [0; 4],
         }
     }
 
-    fn new_l2(l2_len: usize, expire: Option<DateTime<Utc>>, stale: Option<DateTime<Utc>>) -> Self {
+    fn new_l2(
+        l2_len: usize,
+        tags_len: usize,
+        created: DateTime<Utc>,
+        expire: Option<DateTime<Utc>>,
+        stale: Option<DateTime<Utc>>,
+    ) -> Self {
+        let (created_secs, created_nanos) = Self::encode_created(created);
         let (expire_secs, expire_nanos) = Self::encode_timestamp(expire);
         let (stale_secs, stale_nanos) = Self::encode_timestamp(stale);
 
@@ -94,22 +113,26 @@ impl EnvelopeHeader {
             _pad1: [0; 3],
             l1_len: 0,
             l2_len: l2_len as u32,
-            _pad2: [0; 4],
+            tags_len: tags_len as u32,
+            created_secs,
             expire_secs,
-            expire_nanos,
-            _pad3: [0; 4],
             stale_secs,
+            created_nanos,
+            expire_nanos,
             stale_nanos,
-            _pad4: [0; 4],
+            _pad2: [0; 4],
         }
     }
 
     fn new_both(
         l1_len: usize,
         l2_len: usize,
+        tags_len: usize,
+        created: DateTime<Utc>,
         expire: Option<DateTime<Utc>>,
         stale: Option<DateTime<Utc>>,
     ) -> Self {
+        let (created_secs, created_nanos) = Self::encode_created(created);
         let (expire_secs, expire_nanos) = Self::encode_timestamp(expire);
         let (stale_secs, stale_nanos) = Self::encode_timestamp(stale);
 
@@ -118,14 +141,19 @@ impl EnvelopeHeader {
             _pad1: [0; 3],
             l1_len: l1_len as u32,
             l2_len: l2_len as u32,
-            _pad2: [0; 4],
+            tags_len: tags_len as u32,
+            created_secs,
             expire_secs,
-            expire_nanos,
-            _pad3: [0; 4],
             stale_secs,
+            created_nanos,
+            expire_nanos,
             stale_nanos,
-            _pad4: [0; 4],
+            _pad2: [0; 4],
         }
+    }
+
+    fn encode_created(created: DateTime<Utc>) -> (i64, u32) {
+        (created.timestamp(), created.timestamp_subsec_nanos())
     }
 
     fn encode_timestamp(timestamp: Option<DateTime<Utc>>) -> (i64, u32) {
@@ -164,6 +192,17 @@ impl EnvelopeHeader {
         Ok(*bytemuck::from_bytes::<Self>(&data[..Self::SIZE]))
     }
 
+    /// Decode created timestamp. Falls back to `UNIX_EPOCH` for old entries
+    /// that don't have a created timestamp, so any tag invalidation wins.
+    fn decode_created(&self) -> DateTime<Utc> {
+        if self.created_secs == 0 && self.created_nanos == 0 {
+            DateTime::UNIX_EPOCH
+        } else {
+            DateTime::from_timestamp(self.created_secs, self.created_nanos)
+                .unwrap_or(DateTime::UNIX_EPOCH)
+        }
+    }
+
     fn decode_expire(&self) -> Option<DateTime<Utc>> {
         Self::decode_timestamp(self.expire_secs, self.expire_nanos)
     }
@@ -194,39 +233,66 @@ impl CompositionEnvelope {
     pub(crate) fn serialize(&self) -> BackendResult<Bytes> {
         match self {
             CompositionEnvelope::L1(value) => {
-                let header =
-                    EnvelopeHeader::new_l1(value.data().len(), value.expire(), value.stale());
-                let total_size = EnvelopeHeader::SIZE + value.data().len();
+                let tags_bytes = crate::serialize_tags(value.tags())?;
+                let tags_len = tags_bytes.as_ref().map_or(0, Vec::len);
+                let header = EnvelopeHeader::new_l1(
+                    value.data().len(),
+                    tags_len,
+                    value.created(),
+                    value.expire(),
+                    value.stale(),
+                );
+                let total_size = EnvelopeHeader::SIZE + value.data().len() + tags_len;
                 let mut buf = Vec::with_capacity(total_size);
 
                 buf.write_all(header.as_bytes())
                     .map_err(|e| BackendError::InternalError(Box::new(e)))?;
                 buf.write_all(value.data())
                     .map_err(|e| BackendError::InternalError(Box::new(e)))?;
+                if let Some(bytes) = tags_bytes {
+                    buf.write_all(&bytes)
+                        .map_err(|e| BackendError::InternalError(Box::new(e)))?;
+                }
 
                 Ok(Bytes::from(buf))
             }
             CompositionEnvelope::L2(value) => {
-                let header =
-                    EnvelopeHeader::new_l2(value.data().len(), value.expire(), value.stale());
-                let total_size = EnvelopeHeader::SIZE + value.data().len();
+                let tags_bytes = crate::serialize_tags(value.tags())?;
+                let tags_len = tags_bytes.as_ref().map_or(0, Vec::len);
+                let header = EnvelopeHeader::new_l2(
+                    value.data().len(),
+                    tags_len,
+                    value.created(),
+                    value.expire(),
+                    value.stale(),
+                );
+                let total_size = EnvelopeHeader::SIZE + value.data().len() + tags_len;
                 let mut buf = Vec::with_capacity(total_size);
 
                 buf.write_all(header.as_bytes())
                     .map_err(|e| BackendError::InternalError(Box::new(e)))?;
                 buf.write_all(value.data())
                     .map_err(|e| BackendError::InternalError(Box::new(e)))?;
+                if let Some(bytes) = tags_bytes {
+                    buf.write_all(&bytes)
+                        .map_err(|e| BackendError::InternalError(Box::new(e)))?;
+                }
 
                 Ok(Bytes::from(buf))
             }
             CompositionEnvelope::Both { l1, l2 } => {
+                let tags_bytes = crate::serialize_tags(l1.tags())?;
+                let tags_len = tags_bytes.as_ref().map_or(0, Vec::len);
                 let header = EnvelopeHeader::new_both(
                     l1.data().len(),
                     l2.data().len(),
+                    tags_len,
+                    l1.created(),
                     l1.expire(),
                     l1.stale(),
                 );
-                let total_size = EnvelopeHeader::SIZE + l1.data().len() + l2.data().len();
+                let total_size =
+                    EnvelopeHeader::SIZE + l1.data().len() + l2.data().len() + tags_len;
                 let mut buf = Vec::with_capacity(total_size);
 
                 buf.write_all(header.as_bytes())
@@ -235,6 +301,10 @@ impl CompositionEnvelope {
                     .map_err(|e| BackendError::InternalError(Box::new(e)))?;
                 buf.write_all(l2.data())
                     .map_err(|e| BackendError::InternalError(Box::new(e)))?;
+                if let Some(bytes) = tags_bytes {
+                    buf.write_all(&bytes)
+                        .map_err(|e| BackendError::InternalError(Box::new(e)))?;
+                }
 
                 Ok(Bytes::from(buf))
             }
@@ -248,48 +318,69 @@ impl CompositionEnvelope {
 
         let payload_start = EnvelopeHeader::SIZE;
 
+        let tags_len = header.tags_len as usize;
+
+        // Helper to attach tags to a CacheValue if present.
+        let with_tags_opt = |cv: CacheValue<Raw>, tags_bytes: Option<&[u8]>| -> BackendResult<CacheValue<Raw>> {
+            let tags = crate::deserialize_tags(tags_bytes)?;
+            Ok(match tags {
+                Some(tags) => cv.with_tags(tags),
+                None => cv,
+            })
+        };
+
         match header.discriminant {
             0 => {
                 // L1
                 let l1_len = header.l1_len as usize;
-                if data.len() < payload_start + l1_len {
+                let l1_end = payload_start + l1_len;
+                let tags_end = l1_end + tags_len;
+                if data.len() < tags_end {
                     return Err(BackendError::InternalError(Box::new(io::Error::new(
                         io::ErrorKind::UnexpectedEof,
                         format!(
                             "L1 envelope data too short: expected {} bytes, got {}",
-                            payload_start + l1_len,
+                            tags_end,
                             data.len()
                         ),
                     ))));
                 }
 
-                let l1_data = Bytes::copy_from_slice(&data[payload_start..payload_start + l1_len]);
-                Ok(CompositionEnvelope::L1(CacheValue::new(
+                let l1_data = Bytes::copy_from_slice(&data[payload_start..l1_end]);
+                let tags_bytes = (tags_len > 0).then(|| &data[l1_end..tags_end]);
+                let cv = CacheValue::with_created(
                     l1_data,
+                    header.decode_created(),
                     header.decode_expire(),
                     header.decode_stale(),
-                )))
+                );
+                Ok(CompositionEnvelope::L1(with_tags_opt(cv, tags_bytes)?))
             }
             1 => {
                 // L2
                 let l2_len = header.l2_len as usize;
-                if data.len() < payload_start + l2_len {
+                let l2_end = payload_start + l2_len;
+                let tags_end = l2_end + tags_len;
+                if data.len() < tags_end {
                     return Err(BackendError::InternalError(Box::new(io::Error::new(
                         io::ErrorKind::UnexpectedEof,
                         format!(
                             "L2 envelope data too short: expected {} bytes, got {}",
-                            payload_start + l2_len,
+                            tags_end,
                             data.len()
                         ),
                     ))));
                 }
 
-                let l2_data = Bytes::copy_from_slice(&data[payload_start..payload_start + l2_len]);
-                Ok(CompositionEnvelope::L2(CacheValue::new(
+                let l2_data = Bytes::copy_from_slice(&data[payload_start..l2_end]);
+                let tags_bytes = (tags_len > 0).then(|| &data[l2_end..tags_end]);
+                let cv = CacheValue::with_created(
                     l2_data,
+                    header.decode_created(),
                     header.decode_expire(),
                     header.decode_stale(),
-                )))
+                );
+                Ok(CompositionEnvelope::L2(with_tags_opt(cv, tags_bytes)?))
             }
             2 => {
                 // Both
@@ -297,13 +388,14 @@ impl CompositionEnvelope {
                 let l2_len = header.l2_len as usize;
                 let l1_end = payload_start + l1_len;
                 let l2_end = l1_end + l2_len;
+                let tags_end = l2_end + tags_len;
 
-                if data.len() < l2_end {
+                if data.len() < tags_end {
                     return Err(BackendError::InternalError(Box::new(io::Error::new(
                         io::ErrorKind::UnexpectedEof,
                         format!(
                             "Both envelope data too short: expected {} bytes, got {}",
-                            l2_end,
+                            tags_end,
                             data.len()
                         ),
                     ))));
@@ -311,10 +403,23 @@ impl CompositionEnvelope {
 
                 let l1_data = Bytes::copy_from_slice(&data[payload_start..l1_end]);
                 let l2_data = Bytes::copy_from_slice(&data[l1_end..l2_end]);
+                let tags_bytes = (tags_len > 0).then(|| &data[l2_end..tags_end]);
 
+                let l1_cv = CacheValue::with_created(
+                    l1_data,
+                    header.decode_created(),
+                    header.decode_expire(),
+                    header.decode_stale(),
+                );
+                let l2_cv = CacheValue::with_created(
+                    l2_data,
+                    header.decode_created(),
+                    header.decode_expire(),
+                    header.decode_stale(),
+                );
                 Ok(CompositionEnvelope::Both {
-                    l1: CacheValue::new(l1_data, header.decode_expire(), header.decode_stale()),
-                    l2: CacheValue::new(l2_data, header.decode_expire(), header.decode_stale()),
+                    l1: with_tags_opt(l1_cv, tags_bytes)?,
+                    l2: with_tags_opt(l2_cv, tags_bytes)?,
                 })
             }
             _ => Err(BackendError::InternalError(Box::new(io::Error::new(
@@ -333,8 +438,8 @@ mod tests {
     #[test]
     fn test_envelope_header_size() {
         // Ensure header is the expected size for repr(C) with padding
-        // repr(C) adds padding for alignment, so actual size is 48 bytes
-        assert_eq!(EnvelopeHeader::SIZE, 48);
+        // repr(C) adds padding for alignment, so actual size is 56 bytes
+        assert_eq!(EnvelopeHeader::SIZE, 56);
     }
 
     #[test]

--- a/hitbox-backend/src/composition/mod.rs
+++ b/hitbox-backend/src/composition/mod.rs
@@ -62,9 +62,11 @@ use crate::{
 use async_trait::async_trait;
 use envelope::CompositionEnvelope;
 use hitbox_core::{
-    BackendLabel, BoxContext, CacheContext, CacheKey, CacheStatus, CacheValue, Cacheable,
+    BackendLabel, BoxContext, CacheContext, CacheKey, CacheStatus, CacheTag, CacheValue, Cacheable,
     CacheableResponse, Offload, Raw, ResponseSource,
 };
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
 use policy::{
     CompositionReadPolicy, CompositionWritePolicy, OptimisticParallelWritePolicy, ReadResult,
     RefillPolicy, SequentialReadPolicy,
@@ -426,10 +428,18 @@ where
             let result = match read_result {
                 Ok(Some(l1_value)) => {
                     crate::metrics::record_read_bytes(&l1_label, l1_value.data().len());
-                    let (expire, stale) = (l1_value.expire(), l1_value.stale());
+                    let (created, expire, stale, tags) = (
+                        l1_value.created(),
+                        l1_value.expire(),
+                        l1_value.stale(),
+                        l1_value.tags().cloned(),
+                    );
                     let envelope = CompositionEnvelope::L1(l1_value);
                     match envelope.serialize() {
-                        Ok(packed) => Ok(Some(CacheValue::new(packed, expire, stale))),
+                        Ok(packed) => Ok(Some(
+                            CacheValue::with_created(packed, created, expire, stale)
+                                .with_optional_tags(tags),
+                        )),
                         Err(e) => Err(e),
                     }
                 }
@@ -451,10 +461,18 @@ where
             let result = match read_result {
                 Ok(Some(l2_value)) => {
                     crate::metrics::record_read_bytes(&l2_label, l2_value.data().len());
-                    let (expire, stale) = (l2_value.expire(), l2_value.stale());
+                    let (created, expire, stale, tags) = (
+                        l2_value.created(),
+                        l2_value.expire(),
+                        l2_value.stale(),
+                        l2_value.tags().cloned(),
+                    );
                     let envelope = CompositionEnvelope::L2(l2_value);
                     match envelope.serialize() {
-                        Ok(packed) => Ok(Some(CacheValue::new(packed, expire, stale))),
+                        Ok(packed) => Ok(Some(
+                            CacheValue::with_created(packed, created, expire, stale)
+                                .with_optional_tags(tags),
+                        )),
                         Err(e) => Err(e),
                     }
                 }
@@ -596,6 +614,30 @@ where
     fn compressor(&self) -> &dyn Compressor {
         &PassthroughCompressor
     }
+
+    async fn invalidate(&self, tag: &CacheTag) -> BackendResult<()> {
+        let (l1_result, l2_result) =
+            futures::join!(self.l1.invalidate(tag), self.l2.invalidate(tag));
+        l1_result?;
+        l2_result?;
+        Ok(())
+    }
+
+    async fn invalidated(&self, tags: &[CacheTag]) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
+        let (l1_result, l2_result) =
+            futures::join!(self.l1.invalidated(tags), self.l2.invalidated(tags));
+        let mut merged = l1_result?;
+        let l2_timestamps = l2_result?;
+
+        // Union semantics: take the latest timestamp per tag
+        for (tag, ts) in l2_timestamps {
+            merged
+                .entry(tag)
+                .and_modify(|existing| *existing = (*existing).max(ts))
+                .or_insert(ts);
+        }
+        Ok(merged)
+    }
 }
 
 impl<L1, L2, O, R, W> CacheBackend for CompositionBackend<L1, L2, O, R, W>
@@ -681,7 +723,15 @@ where
                                 };
                                 internal_ctx.set_source(ResponseSource::Backend(source));
 
-                                Ok(Some(CacheValue::new(deserialized, meta.expire, meta.stale)))
+                                Ok(Some(
+                                    CacheValue::with_created(
+                                        deserialized,
+                                        meta.created,
+                                        meta.expire,
+                                        meta.stale,
+                                    )
+                                    .with_optional_tags(meta.tags),
+                                ))
                             }
                             None => Err(BackendError::InternalError(Box::new(
                                 std::io::Error::other("deserialization produced no result"),
@@ -729,8 +779,13 @@ where
                     ) {
                         Ok(()) => match deserialized_opt {
                             Some(deserialized) => {
-                                let cache_value =
-                                    CacheValue::new(deserialized, meta.expire, meta.stale);
+                                let cache_value = CacheValue::with_created(
+                                    deserialized,
+                                    meta.created,
+                                    meta.expire,
+                                    meta.stale,
+                                )
+                                .with_optional_tags(meta.tags);
 
                                 // Set cache status and source for L2 hit
                                 internal_ctx.set_status(CacheStatus::Hit);
@@ -824,7 +879,8 @@ where
                         .map_err(|e| BackendError::InternalError(Box::new(e)))?;
 
                     let l1_len = l1_bytes.len();
-                    let l1_value = CacheValue::new(l1_bytes, value.expire(), value.stale());
+                    let l1_value = CacheValue::with_created(l1_bytes, value.created(), value.expire(), value.stale())
+                        .with_optional_tags(value.tags().cloned());
 
                     // Write to L1 with metrics
                     let timer = Timer::new();
@@ -869,7 +925,8 @@ where
                         .map_err(|e| BackendError::InternalError(Box::new(e)))?;
 
                     let l1_len = l1_bytes.len();
-                    let l1_value = CacheValue::new(l1_bytes, value.expire(), value.stale());
+                    let l1_value = CacheValue::with_created(l1_bytes, value.created(), value.expire(), value.stale())
+                        .with_optional_tags(value.tags().cloned());
 
                     // Write to L1 with metrics
                     let timer = Timer::new();
@@ -912,8 +969,12 @@ where
         let l2_len = l2_bytes.len();
 
         // Create raw values for Backend::write
-        let l1_value = CacheValue::new(l1_bytes, value.expire(), value.stale());
-        let l2_value = CacheValue::new(l2_bytes, value.expire(), value.stale());
+        let l1_value =
+            CacheValue::with_created(l1_bytes, value.created(), value.expire(), value.stale())
+                .with_optional_tags(value.tags().cloned());
+        let l2_value =
+            CacheValue::with_created(l2_bytes, value.created(), value.expire(), value.stale())
+                .with_optional_tags(value.tags().cloned());
 
         // Clone backends for 'static closures
         let l1 = self.l1.clone();
@@ -1001,6 +1062,7 @@ mod tests {
     use crate::{Backend, CacheKeyFormat, Compressor, PassthroughCompressor};
     use async_trait::async_trait;
     use chrono::Utc;
+    use hitbox_core::tag::{CacheTag, TagExtractor};
     use hitbox_core::{
         BoxContext, CacheContext, CachePolicy, CacheStatus, CacheValue, CacheableResponse,
         EntityPolicyConfig, Predicate, Raw, ResponseSource,
@@ -1109,11 +1171,16 @@ mod tests {
         type IntoCachedFuture = std::future::Ready<CachePolicy<Self::Cached, Self>>;
         type FromCachedFuture = std::future::Ready<Self>;
 
-        async fn cache_policy<P: Predicate<Subject = Self::Subject> + Send + Sync>(
+        async fn cache_policy<P, TE>(
             self,
             _predicate: P,
+            _tag_extractor: TE,
             _config: &EntityPolicyConfig,
-        ) -> CachePolicy<CacheValue<Self::Cached>, Self> {
+        ) -> (CachePolicy<CacheValue<Self::Cached>, Self>, Vec<CacheTag>)
+        where
+            P: Predicate<Subject = Self::Subject> + Send + Sync,
+            TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
+        {
             unimplemented!("Not used in these tests")
         }
 

--- a/hitbox-backend/src/composition/mod.rs
+++ b/hitbox-backend/src/composition/mod.rs
@@ -60,18 +60,18 @@ use crate::{
     PassthroughCompressor,
 };
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use envelope::CompositionEnvelope;
 use hitbox_core::{
     BackendLabel, BoxContext, CacheContext, CacheKey, CacheStatus, CacheTag, CacheValue, Cacheable,
     CacheableResponse, Offload, Raw, ResponseSource,
 };
-use chrono::{DateTime, Utc};
-use std::collections::HashMap;
 use policy::{
     CompositionReadPolicy, CompositionWritePolicy, OptimisticParallelWritePolicy, ReadResult,
     RefillPolicy, SequentialReadPolicy,
 };
 use smol_str::SmolStr;
+use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -623,7 +623,10 @@ where
         Ok(())
     }
 
-    async fn invalidated(&self, tags: &[CacheTag]) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
+    async fn invalidated(
+        &self,
+        tags: &[CacheTag],
+    ) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
         let (l1_result, l2_result) =
             futures::join!(self.l1.invalidated(tags), self.l2.invalidated(tags));
         let mut merged = l1_result?;
@@ -879,8 +882,13 @@ where
                         .map_err(|e| BackendError::InternalError(Box::new(e)))?;
 
                     let l1_len = l1_bytes.len();
-                    let l1_value = CacheValue::with_created(l1_bytes, value.created(), value.expire(), value.stale())
-                        .with_optional_tags(value.tags().cloned());
+                    let l1_value = CacheValue::with_created(
+                        l1_bytes,
+                        value.created(),
+                        value.expire(),
+                        value.stale(),
+                    )
+                    .with_optional_tags(value.tags().cloned());
 
                     // Write to L1 with metrics
                     let timer = Timer::new();
@@ -925,8 +933,13 @@ where
                         .map_err(|e| BackendError::InternalError(Box::new(e)))?;
 
                     let l1_len = l1_bytes.len();
-                    let l1_value = CacheValue::with_created(l1_bytes, value.created(), value.expire(), value.stale())
-                        .with_optional_tags(value.tags().cloned());
+                    let l1_value = CacheValue::with_created(
+                        l1_bytes,
+                        value.created(),
+                        value.expire(),
+                        value.stale(),
+                    )
+                    .with_optional_tags(value.tags().cloned());
 
                     // Write to L1 with metrics
                     let timer = Timer::new();
@@ -1174,7 +1187,7 @@ mod tests {
         async fn cache_policy<P, TE>(
             self,
             _predicate: P,
-            _tag_extractor: TE,
+            _tag_extractor: Option<TE>,
             _config: &EntityPolicyConfig,
         ) -> (CachePolicy<CacheValue<Self::Cached>, Self>, Vec<CacheTag>)
         where

--- a/hitbox-backend/src/lib.rs
+++ b/hitbox-backend/src/lib.rs
@@ -11,7 +11,10 @@ pub mod format;
 pub mod key;
 pub(crate) mod metrics;
 
-pub use backend::{Backend, BackendResult, CacheBackend, DeleteStatus, SyncBackend, UnsyncBackend};
+pub use backend::{
+    Backend, BackendResult, CacheBackend, DeleteStatus, SyncBackend, UnsyncBackend,
+    deserialize_tags, serialize_tags,
+};
 pub use composition::{Compose, CompositionBackend};
 #[cfg(feature = "gzip")]
 #[cfg_attr(docsrs, doc(cfg(feature = "gzip")))]

--- a/hitbox-backend/tests/composition/builder.rs
+++ b/hitbox-backend/tests/composition/builder.rs
@@ -15,9 +15,10 @@ use hitbox_backend::{
     Backend, BackendResult, CacheBackend, CacheKeyFormat, CompositionBackend, Compressor,
     DeleteStatus, PassthroughCompressor,
 };
+use hitbox_core::tag::{CacheTag, TagExtractor};
 use hitbox_core::{
     BoxContext, CacheContext, CacheKey, CacheValue, CacheableResponse, EntityPolicyConfig,
-    Predicate, Raw,
+    Predicate, Raw, ResponseCachePolicy,
 };
 use serde::{Deserialize, Serialize};
 
@@ -90,11 +91,16 @@ impl CacheableResponse for TestValue {
     type IntoCachedFuture = std::future::Ready<hitbox_core::CachePolicy<Self::Cached, Self>>;
     type FromCachedFuture = std::future::Ready<Self>;
 
-    async fn cache_policy<P: Predicate<Subject = Self::Subject> + Send + Sync>(
+    async fn cache_policy<P, TE>(
         self,
         _predicate: P,
+        _tag_extractor: TE,
         _config: &EntityPolicyConfig,
-    ) -> hitbox_core::ResponseCachePolicy<Self> {
+    ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
+    where
+        P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
+    {
         unimplemented!()
     }
 

--- a/hitbox-backend/tests/composition/builder.rs
+++ b/hitbox-backend/tests/composition/builder.rs
@@ -94,7 +94,7 @@ impl CacheableResponse for TestValue {
     async fn cache_policy<P, TE>(
         self,
         _predicate: P,
-        _tag_extractor: TE,
+        _tag_extractor: Option<TE>,
         _config: &EntityPolicyConfig,
     ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where

--- a/hitbox-backend/tests/composition/context_refill.rs
+++ b/hitbox-backend/tests/composition/context_refill.rs
@@ -7,9 +7,10 @@ use std::sync::Arc;
 use chrono::Utc;
 use hitbox_backend::composition::CompositionBackend;
 use hitbox_backend::{CacheBackend, SyncBackend};
+use hitbox_core::tag::{CacheTag, TagExtractor};
 use hitbox_core::{
     BoxContext, CacheContext, CacheKey, CacheValue, CacheableResponse, EntityPolicyConfig,
-    Predicate,
+    Predicate, ResponseCachePolicy,
 };
 use serde::{Deserialize, Serialize};
 
@@ -35,11 +36,16 @@ impl CacheableResponse for TestValue {
     type IntoCachedFuture = std::future::Ready<hitbox_core::CachePolicy<Self::Cached, Self>>;
     type FromCachedFuture = std::future::Ready<Self>;
 
-    async fn cache_policy<P: Predicate<Subject = Self::Subject> + Send + Sync>(
+    async fn cache_policy<P, TE>(
         self,
         _predicate: P,
+        _tag_extractor: TE,
         _config: &EntityPolicyConfig,
-    ) -> hitbox_core::ResponseCachePolicy<Self> {
+    ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
+    where
+        P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
+    {
         unimplemented!()
     }
 

--- a/hitbox-backend/tests/composition/context_refill.rs
+++ b/hitbox-backend/tests/composition/context_refill.rs
@@ -39,7 +39,7 @@ impl CacheableResponse for TestValue {
     async fn cache_policy<P, TE>(
         self,
         _predicate: P,
-        _tag_extractor: TE,
+        _tag_extractor: Option<TE>,
         _config: &EntityPolicyConfig,
     ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where

--- a/hitbox-backend/tests/composition/error_handling.rs
+++ b/hitbox-backend/tests/composition/error_handling.rs
@@ -84,7 +84,7 @@ impl CacheableResponse for TestValue {
     async fn cache_policy<P, TE>(
         self,
         _predicate: P,
-        _tag_extractor: TE,
+        _tag_extractor: Option<TE>,
         _config: &EntityPolicyConfig,
     ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where

--- a/hitbox-backend/tests/composition/error_handling.rs
+++ b/hitbox-backend/tests/composition/error_handling.rs
@@ -5,9 +5,10 @@ use hitbox_backend::{
     Backend, BackendError, BackendResult, CacheBackend, CacheKeyFormat, CompositionBackend,
     Compressor, DeleteStatus, PassthroughCompressor,
 };
+use hitbox_core::tag::{CacheTag, TagExtractor};
 use hitbox_core::{
     BoxContext, CacheContext, CacheKey, CacheValue, CacheableResponse, EntityPolicyConfig,
-    Predicate, Raw,
+    Predicate, Raw, ResponseCachePolicy,
 };
 use serde::{Deserialize, Serialize};
 
@@ -80,11 +81,16 @@ impl CacheableResponse for TestValue {
     type IntoCachedFuture = std::future::Ready<hitbox_core::CachePolicy<Self::Cached, Self>>;
     type FromCachedFuture = std::future::Ready<Self>;
 
-    async fn cache_policy<P: Predicate<Subject = Self::Subject> + Send + Sync>(
+    async fn cache_policy<P, TE>(
         self,
         _predicate: P,
+        _tag_extractor: TE,
         _config: &EntityPolicyConfig,
-    ) -> hitbox_core::ResponseCachePolicy<Self> {
+    ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
+    where
+        P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
+    {
         unimplemented!()
     }
 

--- a/hitbox-backend/tests/composition/nested.rs
+++ b/hitbox-backend/tests/composition/nested.rs
@@ -37,7 +37,7 @@ impl CacheableResponse for TestValue {
     async fn cache_policy<P, TE>(
         self,
         _predicate: P,
-        _tag_extractor: TE,
+        _tag_extractor: Option<TE>,
         _config: &EntityPolicyConfig,
     ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where

--- a/hitbox-backend/tests/composition/nested.rs
+++ b/hitbox-backend/tests/composition/nested.rs
@@ -7,9 +7,10 @@ use chrono::Utc;
 use std::sync::Arc;
 
 use hitbox_backend::{CacheBackend, CompositionBackend, SyncBackend};
+use hitbox_core::tag::{CacheTag, TagExtractor};
 use hitbox_core::{
     BoxContext, CacheContext, CacheKey, CacheValue, CacheableResponse, EntityPolicyConfig,
-    Predicate,
+    Predicate, ResponseCachePolicy,
 };
 use serde::{Deserialize, Serialize};
 
@@ -33,11 +34,16 @@ impl CacheableResponse for TestValue {
     type IntoCachedFuture = std::future::Ready<hitbox_core::CachePolicy<Self::Cached, Self>>;
     type FromCachedFuture = std::future::Ready<Self>;
 
-    async fn cache_policy<P: Predicate<Subject = Self::Subject> + Send + Sync>(
+    async fn cache_policy<P, TE>(
         self,
         _predicate: P,
+        _tag_extractor: TE,
         _config: &EntityPolicyConfig,
-    ) -> hitbox_core::ResponseCachePolicy<Self> {
+    ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
+    where
+        P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
+    {
         unimplemented!()
     }
 

--- a/hitbox-backend/tests/composition/trait_objects.rs
+++ b/hitbox-backend/tests/composition/trait_objects.rs
@@ -86,7 +86,7 @@ impl CacheableResponse for TestValue {
     async fn cache_policy<P, TE>(
         self,
         _predicate: P,
-        _tag_extractor: TE,
+        _tag_extractor: Option<TE>,
         _config: &EntityPolicyConfig,
     ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where

--- a/hitbox-backend/tests/composition/trait_objects.rs
+++ b/hitbox-backend/tests/composition/trait_objects.rs
@@ -9,9 +9,10 @@ use hitbox_backend::{
     Backend, BackendResult, CacheBackend, CacheKeyFormat, CompositionBackend, Compressor,
     DeleteStatus, PassthroughCompressor, SyncBackend,
 };
+use hitbox_core::tag::{CacheTag, TagExtractor};
 use hitbox_core::{
     BoxContext, CacheContext, CacheKey, CacheValue, CacheableResponse, EntityPolicyConfig,
-    Predicate, Raw,
+    Predicate, Raw, ResponseCachePolicy,
 };
 use serde::{Deserialize, Serialize};
 
@@ -82,11 +83,16 @@ impl CacheableResponse for TestValue {
     type IntoCachedFuture = std::future::Ready<hitbox_core::CachePolicy<Self::Cached, Self>>;
     type FromCachedFuture = std::future::Ready<Self>;
 
-    async fn cache_policy<P: Predicate<Subject = Self::Subject> + Send + Sync>(
+    async fn cache_policy<P, TE>(
         self,
         _predicate: P,
+        _tag_extractor: TE,
         _config: &EntityPolicyConfig,
-    ) -> hitbox_core::ResponseCachePolicy<Self> {
+    ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
+    where
+        P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
+    {
         unimplemented!()
     }
 

--- a/hitbox-backend/tests/erased/mod.rs
+++ b/hitbox-backend/tests/erased/mod.rs
@@ -6,8 +6,10 @@ use chrono::Utc;
 use hitbox_backend::{
     Backend, BackendResult, CacheBackend, CacheKeyFormat, CompositionBackend, SyncBackend,
 };
+use hitbox_core::tag::{CacheTag, TagExtractor};
 use hitbox_core::{
-    BoxContext, CacheContext, CacheKey, CacheValue, CacheableResponse, EntityPolicyConfig, Raw,
+    BoxContext, CacheContext, CacheKey, CacheValue, CacheableResponse, EntityPolicyConfig,
+    Predicate, Raw, ResponseCachePolicy,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -75,13 +77,15 @@ impl CacheableResponse for Value {
     type IntoCachedFuture = std::future::Ready<hitbox_core::CachePolicy<Self::Cached, Self>>;
     type FromCachedFuture = std::future::Ready<Self>;
 
-    async fn cache_policy<P>(
+    async fn cache_policy<P, TE>(
         self,
         _predicates: P,
+        _tag_extractor: TE,
         _: &EntityPolicyConfig,
-    ) -> hitbox_core::ResponseCachePolicy<Self>
+    ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where
-        P: hitbox_core::Predicate<Subject = Self::Subject> + Send + Sync,
+        P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
     {
         todo!()
     }

--- a/hitbox-backend/tests/erased/mod.rs
+++ b/hitbox-backend/tests/erased/mod.rs
@@ -80,7 +80,7 @@ impl CacheableResponse for Value {
     async fn cache_policy<P, TE>(
         self,
         _predicates: P,
-        _tag_extractor: TE,
+        _tag_extractor: Option<TE>,
         _: &EntityPolicyConfig,
     ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where

--- a/hitbox-backend/tests/metrics/mod.rs
+++ b/hitbox-backend/tests/metrics/mod.rs
@@ -108,7 +108,7 @@ impl CacheableResponse for TestData {
     async fn cache_policy<P, TE>(
         self,
         _predicates: P,
-        _tag_extractor: TE,
+        _tag_extractor: Option<TE>,
         _: &EntityPolicyConfig,
     ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where

--- a/hitbox-backend/tests/metrics/mod.rs
+++ b/hitbox-backend/tests/metrics/mod.rs
@@ -14,9 +14,10 @@ use hitbox_backend::{
     Backend, BackendResult, CacheBackend, CacheKeyFormat, Compressor, DeleteStatus,
     PassthroughCompressor, SyncBackend,
 };
+use hitbox_core::tag::{CacheTag, TagExtractor};
 use hitbox_core::{
     BackendLabel, BoxContext, CacheContext, CacheKey, CacheValue, CacheableResponse,
-    EntityPolicyConfig, Raw,
+    EntityPolicyConfig, Predicate, Raw, ResponseCachePolicy,
 };
 use metrics_util::debugging::{DebugValue, DebuggingRecorder};
 use metrics_util::{CompositeKey, MetricKind};
@@ -104,13 +105,15 @@ impl CacheableResponse for TestData {
     type IntoCachedFuture = std::future::Ready<hitbox_core::CachePolicy<Self::Cached, Self>>;
     type FromCachedFuture = std::future::Ready<Self>;
 
-    async fn cache_policy<P>(
+    async fn cache_policy<P, TE>(
         self,
         _predicates: P,
+        _tag_extractor: TE,
         _: &EntityPolicyConfig,
-    ) -> hitbox_core::ResponseCachePolicy<Self>
+    ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where
-        P: hitbox_core::Predicate<Subject = Self::Subject> + Send + Sync,
+        P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
     {
         todo!()
     }

--- a/hitbox-configuration/src/config.rs
+++ b/hitbox-configuration/src/config.rs
@@ -12,10 +12,16 @@ use hitbox_http::{
 use http::Method;
 use serde::{Deserialize, Serialize};
 
+use hitbox_core::tag::NeutralTagExtractor;
+use hitbox_http::{CacheableHttpRequest, CacheableHttpResponse};
+
 use crate::{
     ConfigError, Request, RequestPredicate, Response, ResponsePredicate,
     endpoint::{Endpoint, RequestExtractor},
-    extractors::Extractor,
+    extractors::{
+        Extractor,
+        tag::{self as tag_config, TagsConfig},
+    },
     types::MaybeUndefined,
 };
 
@@ -110,6 +116,10 @@ pub struct ConfigEndpoint {
     pub response: MaybeUndefined<Response>,
     #[serde(default)]
     pub extractors: MaybeUndefined<Vec<Extractor>>,
+    /// Per-side tag extractor configuration. See [`TagsConfig`] for the
+    /// supported YAML shape (`tags: { request: [...], response: [...] }`).
+    #[serde(default)]
+    pub tags: MaybeUndefined<TagsConfig>,
     pub policy: PolicyConfig,
 }
 
@@ -163,10 +173,32 @@ impl ConfigEndpoint {
                 NeutralRequestPredicate::<ReqBody>::new().method(MethodOp::eq(Method::GET)),
             ) as RequestPredicate<ReqBody>,
         });
+        let (request_tag_cfg, response_tag_cfg) = match self.tags {
+            MaybeUndefined::Value(TagsConfig { request, response }) => (request, response),
+            _ => (Vec::new(), Vec::new()),
+        };
+        let request_tag_extractors: crate::endpoint::ArcRequestTagExtractor<ReqBody> =
+            if request_tag_cfg.is_empty() {
+                Arc::new(NeutralTagExtractor::<CacheableHttpRequest<ReqBody>>::default())
+            } else {
+                Arc::from(tag_config::request::build_request_boxed::<ReqBody>(
+                    request_tag_cfg,
+                )?)
+            };
+        let response_tag_extractors: crate::endpoint::ArcResponseTagExtractor<ResBody> =
+            if response_tag_cfg.is_empty() {
+                Arc::new(NeutralTagExtractor::<CacheableHttpResponse<ResBody>>::default())
+            } else {
+                Arc::from(tag_config::build_response_boxed::<CacheableHttpResponse<ResBody>>(
+                    response_tag_cfg,
+                ))
+            };
         Ok(Endpoint {
             extractors,
             request_predicates,
             response_predicates,
+            request_tag_extractors,
+            response_tag_extractors,
             policy: Arc::new(self.policy.into()),
         })
     }

--- a/hitbox-configuration/src/config.rs
+++ b/hitbox-configuration/src/config.rs
@@ -47,6 +47,22 @@ impl From<StalePolicy> for policy::StalePolicy {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, Default)]
+pub enum TagInvalidation {
+    #[default]
+    Check,
+    Skip,
+}
+
+impl From<TagInvalidation> for policy::TagInvalidation {
+    fn from(t: TagInvalidation) -> Self {
+        match t {
+            TagInvalidation::Check => policy::TagInvalidation::Check,
+            TagInvalidation::Skip => policy::TagInvalidation::Skip,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Default)]
 pub struct CacheBehaviorPolicy {
     #[serde(default)]
@@ -70,6 +86,8 @@ pub struct EnabledCacheConfig {
     #[serde(default)]
     policy: CacheBehaviorPolicy,
     concurrency: Option<NonZeroU8>,
+    #[serde(default)]
+    tag_invalidation: TagInvalidation,
 }
 
 impl From<EnabledCacheConfig> for policy::EnabledCacheConfig {
@@ -79,6 +97,7 @@ impl From<EnabledCacheConfig> for policy::EnabledCacheConfig {
             stale: s.stale,
             policy: s.policy.into(),
             concurrency: s.concurrency,
+            tag_invalidation: s.tag_invalidation.into(),
         }
     }
 }
@@ -189,9 +208,9 @@ impl ConfigEndpoint {
             if response_tag_cfg.is_empty() {
                 Arc::new(NeutralTagExtractor::<CacheableHttpResponse<ResBody>>::default())
             } else {
-                Arc::from(tag_config::build_response_boxed::<CacheableHttpResponse<ResBody>>(
-                    response_tag_cfg,
-                ))
+                Arc::from(tag_config::build_response_boxed::<
+                    CacheableHttpResponse<ResBody>,
+                >(response_tag_cfg))
             };
         Ok(Endpoint {
             extractors,

--- a/hitbox-configuration/src/endpoint.rs
+++ b/hitbox-configuration/src/endpoint.rs
@@ -2,8 +2,9 @@ use std::{fmt::Debug, sync::Arc};
 
 use hitbox::{
     Extractor, Predicate,
-    config::{BoxExtractor, BoxPredicate, CacheConfig, CacheConfigs},
+    config::{BoxExtractor, BoxPredicate, BoxTagExtractor, CacheConfig, CacheConfigs},
     policy::PolicyConfig,
+    tag::TagExtractor,
 };
 use hitbox_http::{CacheableHttpRequest, CacheableHttpResponse};
 
@@ -12,6 +13,8 @@ use crate::ConfigEndpoint;
 pub type RequestPredicate<ReqBody> = BoxPredicate<CacheableHttpRequest<ReqBody>>;
 pub type ResponsePredicate<ResBody> = BoxPredicate<CacheableHttpResponse<ResBody>>;
 pub type RequestExtractor<ReqBody> = BoxExtractor<CacheableHttpRequest<ReqBody>>;
+pub type RequestTagExtractor<ReqBody> = BoxTagExtractor<CacheableHttpRequest<ReqBody>>;
+pub type ResponseTagExtractor<ResBody> = BoxTagExtractor<CacheableHttpResponse<ResBody>>;
 
 pub type ArcRequestPredicate<ReqBody> =
     Arc<dyn Predicate<Subject = CacheableHttpRequest<ReqBody>> + Send + Sync>;
@@ -19,6 +22,10 @@ pub type ArcResponsePredicate<ResBody> =
     Arc<dyn Predicate<Subject = CacheableHttpResponse<ResBody>> + Send + Sync>;
 pub type ArcRequestExtractor<ReqBody> =
     Arc<dyn Extractor<Subject = CacheableHttpRequest<ReqBody>> + Send + Sync>;
+pub type ArcRequestTagExtractor<ReqBody> =
+    Arc<dyn TagExtractor<Subject = CacheableHttpRequest<ReqBody>> + Send + Sync>;
+pub type ArcResponseTagExtractor<ResBody> =
+    Arc<dyn TagExtractor<Subject = CacheableHttpResponse<ResBody>> + Send + Sync>;
 
 pub struct Endpoint<ReqBody, ResBody>
 where
@@ -28,6 +35,8 @@ where
     pub request_predicates: ArcRequestPredicate<ReqBody>,
     pub response_predicates: ArcResponsePredicate<ResBody>,
     pub extractors: ArcRequestExtractor<ReqBody>,
+    pub request_tag_extractors: ArcRequestTagExtractor<ReqBody>,
+    pub response_tag_extractors: ArcResponseTagExtractor<ResBody>,
     pub policy: Arc<PolicyConfig>,
 }
 
@@ -56,6 +65,8 @@ where
             request_predicates: Arc::clone(&self.request_predicates),
             response_predicates: Arc::clone(&self.response_predicates),
             extractors: Arc::clone(&self.extractors),
+            request_tag_extractors: Arc::clone(&self.request_tag_extractors),
+            response_tag_extractors: Arc::clone(&self.response_tag_extractors),
             policy: Arc::clone(&self.policy),
         }
     }
@@ -90,6 +101,8 @@ where
     type RequestPredicate = ArcRequestPredicate<ReqBody>;
     type ResponsePredicate = ArcResponsePredicate<ResBody>;
     type Extractor = ArcRequestExtractor<ReqBody>;
+    type RequestTagExtractor = ArcRequestTagExtractor<ReqBody>;
+    type ResponseTagExtractor = ArcResponseTagExtractor<ResBody>;
 
     fn request_predicates(&self) -> Self::RequestPredicate {
         Arc::clone(&self.request_predicates)
@@ -101,6 +114,14 @@ where
 
     fn extractors(&self) -> Self::Extractor {
         Arc::clone(&self.extractors)
+    }
+
+    fn request_tag_extractors(&self) -> Self::RequestTagExtractor {
+        Arc::clone(&self.request_tag_extractors)
+    }
+
+    fn response_tag_extractors(&self) -> Self::ResponseTagExtractor {
+        Arc::clone(&self.response_tag_extractors)
     }
 
     fn policy(&self) -> Arc<PolicyConfig> {
@@ -145,6 +166,8 @@ where
     request_predicates: Option<ArcRequestPredicate<ReqBody>>,
     response_predicates: Option<ArcResponsePredicate<ResBody>>,
     extractors: Option<ArcRequestExtractor<ReqBody>>,
+    request_tag_extractors: Option<ArcRequestTagExtractor<ReqBody>>,
+    response_tag_extractors: Option<ArcResponseTagExtractor<ResBody>>,
     policy: Arc<PolicyConfig>,
 }
 
@@ -159,6 +182,8 @@ where
             request_predicates: None,
             response_predicates: None,
             extractors: None,
+            request_tag_extractors: None,
+            response_tag_extractors: None,
             policy: Arc::new(PolicyConfig::default()),
         }
     }
@@ -196,6 +221,28 @@ where
         }
     }
 
+    /// Set the request-side tag extractor.
+    pub fn request_tag_extractor<T>(self, extractor: T) -> Self
+    where
+        T: TagExtractor<Subject = CacheableHttpRequest<ReqBody>> + Send + Sync + 'static,
+    {
+        Self {
+            request_tag_extractors: Some(Arc::new(extractor)),
+            ..self
+        }
+    }
+
+    /// Set the response-side tag extractor.
+    pub fn response_tag_extractor<T>(self, extractor: T) -> Self
+    where
+        T: TagExtractor<Subject = CacheableHttpResponse<ResBody>> + Send + Sync + 'static,
+    {
+        Self {
+            response_tag_extractors: Some(Arc::new(extractor)),
+            ..self
+        }
+    }
+
     /// Set the cache policy.
     pub fn policy(self, policy: PolicyConfig) -> Self {
         Self {
@@ -223,6 +270,12 @@ where
                 .response_predicates
                 .unwrap_or(default.response_predicates),
             extractors: self.extractors.unwrap_or(default.extractors),
+            request_tag_extractors: self
+                .request_tag_extractors
+                .unwrap_or(default.request_tag_extractors),
+            response_tag_extractors: self
+                .response_tag_extractors
+                .unwrap_or(default.response_tag_extractors),
             policy: self.policy,
         }
     }

--- a/hitbox-configuration/src/extractors/mod.rs
+++ b/hitbox-configuration/src/extractors/mod.rs
@@ -13,8 +13,11 @@ pub mod header;
 pub mod method;
 pub mod path;
 pub mod query;
+pub mod tag;
 pub mod transform;
 pub mod version;
+
+pub use tag::{RequestTagExtractor, ResponseTagExtractor, TagsConfig};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum Extractor {

--- a/hitbox-configuration/src/extractors/tag/mod.rs
+++ b/hitbox-configuration/src/extractors/tag/mod.rs
@@ -1,0 +1,262 @@
+//! Configuration types for cache tag extractors.
+//!
+//! Tag extraction config is split per side:
+//!
+//! - [`request::RequestTagExtractor`] — request-side. Supports [`Static`]
+//!   (subject-agnostic literal / key=value tags) plus every variant of
+//!   [`crate::extractors::Extractor`] (Path, Method, Query, Body, Header,
+//!   Version) — those reuse the
+//!   [`TagAdapter`](hitbox_core::tag::TagAdapter) compatibility layer to
+//!   turn a key extractor into a tag extractor.
+//! - [`ResponseTagExtractor`] — response-side. Currently only `Static`.
+//!   Dynamic response variants (e.g. extracting an ETag header from the
+//!   response, or fields from the response body) are blocked on a
+//!   response-shape extractor enum that does not yet exist; once it lands,
+//!   mirrored variants will be added here.
+//!
+//! Both sides share the [`Static`] form, which emits a fixed list of tags.
+//! Three YAML shapes are supported (no overlap, no string parsing — each
+//! shape has a single, unambiguous semantic):
+//!
+//! ```yaml
+//! # Strings → bare-key tags (literal tag names with no `=`).
+//! - Static: "endpoint:users"
+//! - Static: ["v1", "deprecated"]
+//!
+//! # Mapping → "key=value" tags (insertion order preserved).
+//! - Static:
+//!     user: "42"
+//!     region: "eu"
+//! ```
+
+pub mod request;
+
+use hitbox::config::BoxTagExtractor;
+use hitbox_core::tag::ExtractorExt;
+use hitbox_core::{KeyPart, StaticExtractor};
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+pub use request::RequestTagExtractor;
+
+/// Static tag form — three YAML shapes, each with a single semantic.
+///
+/// Strings are **literal tag names** (bare-key
+/// [`CacheTag`](hitbox_core::tag::CacheTag)s with no `=`). Mappings are
+/// **`"key=value"` tags**. The forms do not overlap — there's no string
+/// parsing, each shape unambiguously describes what it produces.
+///
+/// ```yaml
+/// # Single literal tag.
+/// Static: "endpoint:users"
+///
+/// # List of literal tags.
+/// Static:
+///   - "v1"
+///   - "deprecated"
+///
+/// # Native mapping → "key=value" tags, insertion order preserved.
+/// Static:
+///   user: "42"
+///   region: "eu"
+/// ```
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[serde(untagged)]
+pub enum Static {
+    /// Single literal tag (bare key, no value).
+    Single(String),
+    /// List of literal tags (each a bare key, no value).
+    List(Vec<String>),
+    /// Mapping of `key → value` pairs, emitted as `"key=value"` tags.
+    Map(IndexMap<String, String>),
+}
+
+impl Static {
+    /// Convert into the [`KeyPart`] sequence consumed by
+    /// [`StaticExtractor`] (and via [`ExtractorExt::as_tag`], by
+    /// [`TagAdapter`](hitbox_core::tag::TagAdapter)).
+    pub(crate) fn into_key_parts(self) -> Vec<KeyPart> {
+        match self {
+            Static::Single(s) => vec![KeyPart::new(s, None::<&str>)],
+            Static::List(items) => items
+                .into_iter()
+                .map(|s| KeyPart::new(s, None::<&str>))
+                .collect(),
+            Static::Map(map) => map
+                .into_iter()
+                .map(|(k, v)| KeyPart::new(k, Some(v)))
+                .collect(),
+        }
+    }
+}
+
+/// Configuration enum for response-side tag extractors.
+///
+/// Currently only `Static` is supported. Once a response-shape extractor
+/// enum exists, its variants will be mirrored here for the same
+/// [`TagAdapter`](hitbox_core::tag::TagAdapter)-based compatibility layer
+/// already used for request-side tags.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum ResponseTagExtractor {
+    /// Emit a fixed list of tags. See [`Static`] for the supported shapes.
+    Static(Static),
+}
+
+impl ResponseTagExtractor {
+    /// Convert this configuration variant into a runtime tag extractor.
+    pub fn into_tag_extractor<S>(self) -> BoxTagExtractor<S>
+    where
+        S: Send + 'static,
+    {
+        match self {
+            ResponseTagExtractor::Static(s) => {
+                Box::new(StaticExtractor::<S>::new(s.into_key_parts()).as_tag())
+            }
+        }
+    }
+}
+
+/// Build a boxed runtime tag extractor for the response side from a list
+/// of [`ResponseTagExtractor`] config variants.
+pub fn build_response_boxed<S>(configs: Vec<ResponseTagExtractor>) -> BoxTagExtractor<S>
+where
+    S: Send + 'static,
+{
+    let mut all_parts: Vec<KeyPart> = Vec::new();
+    for cfg in configs {
+        match cfg {
+            ResponseTagExtractor::Static(s) => {
+                all_parts.extend(s.into_key_parts());
+            }
+        }
+    }
+    Box::new(StaticExtractor::<S>::new(all_parts).as_tag())
+}
+
+/// Grouping of request- and response-side tag extractor configs.
+///
+/// Mirrors the YAML shape:
+///
+/// ```yaml
+/// tags:
+///   request:
+///     - Static:
+///         user: "42"
+///     - Path: "/v1/authors/{author_id}/books/{book_id}"
+///   response:
+///     - Static:
+///         etag: "v1"
+/// ```
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Default)]
+pub struct TagsConfig {
+    /// Request-side tag extractors. Empty = neutral (no request tags).
+    #[serde(default)]
+    pub request: Vec<RequestTagExtractor>,
+    /// Response-side tag extractors. Empty = neutral (no response tags).
+    #[serde(default)]
+    pub response: Vec<ResponseTagExtractor>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hitbox_core::tag::TagExtractor as TagExtractorTrait;
+
+    #[tokio::test]
+    async fn static_single_emits_one_literal_tag() {
+        let cfg = ResponseTagExtractor::Static(Static::Single("endpoint:users".into()));
+        let ext: BoxTagExtractor<()> = cfg.into_tag_extractor();
+        let (_subject, tags) = ext.extract_tags(()).await;
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].as_str(), "endpoint:users");
+    }
+
+    #[tokio::test]
+    async fn static_list_emits_literal_tags() {
+        let cfg =
+            ResponseTagExtractor::Static(Static::List(vec!["v1".into(), "deprecated".into()]));
+        let ext: BoxTagExtractor<()> = cfg.into_tag_extractor();
+        let (_subject, tags) = ext.extract_tags(()).await;
+        assert_eq!(tags.len(), 2);
+        assert_eq!(tags[0].as_str(), "v1");
+        assert_eq!(tags[1].as_str(), "deprecated");
+    }
+
+    #[tokio::test]
+    async fn static_map_emits_key_value_tags_in_insertion_order() {
+        let mut map = IndexMap::new();
+        map.insert("user".into(), "42".into());
+        map.insert("region".into(), "eu".into());
+        let cfg = ResponseTagExtractor::Static(Static::Map(map));
+        let ext: BoxTagExtractor<()> = cfg.into_tag_extractor();
+        let (_subject, tags) = ext.extract_tags(()).await;
+        assert_eq!(tags.len(), 2);
+        assert_eq!(tags[0].as_str(), "user=42");
+        assert_eq!(tags[1].as_str(), "region=eu");
+    }
+
+    #[test]
+    fn static_single_round_trips_via_yaml() {
+        let yaml = r#"Static: "endpoint:users""#;
+        let parsed: ResponseTagExtractor = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(
+            parsed,
+            ResponseTagExtractor::Static(Static::Single("endpoint:users".into()))
+        );
+    }
+
+    #[test]
+    fn static_list_round_trips_via_yaml() {
+        let yaml = r#"
+            Static:
+              - "v1"
+              - "deprecated"
+        "#;
+        let parsed: ResponseTagExtractor = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(
+            parsed,
+            ResponseTagExtractor::Static(Static::List(vec!["v1".into(), "deprecated".into()]))
+        );
+    }
+
+    #[test]
+    fn static_map_round_trips_via_yaml() {
+        let yaml = r#"
+            Static:
+              user: "42"
+              region: "eu"
+        "#;
+        let parsed: ResponseTagExtractor = serde_saphyr::from_str(yaml).unwrap();
+        let mut map = IndexMap::new();
+        map.insert("user".into(), "42".into());
+        map.insert("region".into(), "eu".into());
+        assert_eq!(parsed, ResponseTagExtractor::Static(Static::Map(map)));
+    }
+
+    #[test]
+    fn tags_config_round_trips_with_both_sides() {
+        let yaml = r#"
+            request:
+              - Static:
+                  user: "42"
+            response:
+              - Static:
+                  etag: "v1"
+        "#;
+        let parsed: TagsConfig = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(parsed.request.len(), 1);
+        assert_eq!(parsed.response.len(), 1);
+    }
+
+    #[test]
+    fn tags_config_omits_either_side() {
+        let yaml = r#"
+            response:
+              - Static:
+                  etag: "v1"
+        "#;
+        let parsed: TagsConfig = serde_saphyr::from_str(yaml).unwrap();
+        assert!(parsed.request.is_empty());
+        assert_eq!(parsed.response.len(), 1);
+    }
+}

--- a/hitbox-configuration/src/extractors/tag/request.rs
+++ b/hitbox-configuration/src/extractors/tag/request.rs
@@ -1,0 +1,175 @@
+//! Request-side tag extractor configuration.
+//!
+//! [`RequestTagExtractor`] mirrors [`crate::extractors::Extractor`] and adds
+//! the [`Static`](super::Static) variant. Every key extractor variant
+//! (Path, Method, Query, Body, Header, Version) is reused here as a tag
+//! extractor via the [`TagAdapter`](hitbox_core::tag::TagAdapter)
+//! compatibility layer — each `KeyPart` produced by the underlying
+//! extractor becomes a [`CacheTag`](hitbox_core::tag::CacheTag) of the form
+//! `"key=value"` (or just `"key"` when the value is `None`).
+//!
+//! ```yaml
+//! - Static:
+//!     user: "42"
+//! - Path: "/v1/authors/{author_id}/books/{book_id}"
+//! - Method:
+//! ```
+//!
+//! When multiple variants are supplied, the resulting tag extractors are
+//! combined via [`ChainTagExtractor`](hitbox_core::tag::ChainTagExtractor)
+//! at runtime — tags from each entry are concatenated in order.
+
+use std::fmt::Debug;
+
+use hitbox::config::{BoxExtractor, BoxTagExtractor};
+use hitbox_core::tag::{ChainTagExtractor, ExtractorExt, NeutralTagExtractor, TagAdapter};
+use hitbox_core::StaticExtractor;
+use hitbox_http::CacheableHttpRequest;
+use hitbox_http::extractors::NeutralExtractor;
+use serde::{Deserialize, Serialize};
+
+use super::Static;
+use crate::error::ConfigError;
+use crate::extractors::{
+    body::BodyOperation, header::HeaderOperation, method::Method, path::Path,
+    query::QueryOperation, version::Version, Extractor,
+};
+
+/// Request-side tag extractor configuration.
+///
+/// `Static` emits literal / `key=value` tags (see [`Static`]). All other
+/// variants reuse a key [`Extractor`] and wrap it with [`TagAdapter`] —
+/// the same compatibility layer exposed by [`ExtractorExt::as_tag`] in
+/// `hitbox-core`.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum RequestTagExtractor {
+    /// Subject-agnostic literal / `key=value` tags.
+    Static(Static),
+    /// Path key extractor reused as a tag extractor.
+    Path(Path),
+    /// HTTP method extractor reused as a tag extractor.
+    Method(Method),
+    /// Query parameter extractor reused as a tag extractor.
+    Query(QueryOperation),
+    /// Request body extractor reused as a tag extractor.
+    Body(BodyOperation),
+    /// Request header extractor reused as a tag extractor.
+    Header(HeaderOperation),
+    /// HTTP version extractor reused as a tag extractor.
+    Version(Version),
+}
+
+impl RequestTagExtractor {
+    /// Convert this configuration variant into a single boxed runtime tag
+    /// extractor.
+    fn into_tag_extractor<ReqBody>(
+        self,
+    ) -> Result<BoxTagExtractor<CacheableHttpRequest<ReqBody>>, ConfigError>
+    where
+        ReqBody: hyper::body::Body + Send + Debug + 'static,
+        ReqBody::Error: Debug + Send,
+        ReqBody::Data: Send,
+    {
+        match self {
+            RequestTagExtractor::Static(s) => Ok(Box::new(
+                StaticExtractor::<CacheableHttpRequest<ReqBody>>::new(s.into_key_parts()).as_tag(),
+            )),
+            RequestTagExtractor::Path(p) => wrap_extractor::<ReqBody>(Extractor::Path(p)),
+            RequestTagExtractor::Method(m) => wrap_extractor::<ReqBody>(Extractor::Method(m)),
+            RequestTagExtractor::Query(q) => wrap_extractor::<ReqBody>(Extractor::Query(q)),
+            RequestTagExtractor::Body(b) => wrap_extractor::<ReqBody>(Extractor::Body(b)),
+            RequestTagExtractor::Header(h) => wrap_extractor::<ReqBody>(Extractor::Header(h)),
+            RequestTagExtractor::Version(v) => wrap_extractor::<ReqBody>(Extractor::Version(v)),
+        }
+    }
+}
+
+/// Build a single-extractor [`TagAdapter`] from one [`Extractor`] variant.
+///
+/// The extractor is chained onto a fresh [`NeutralExtractor`] base; the
+/// resulting boxed key extractor is wrapped with [`TagAdapter`], turning
+/// every [`KeyPart`](hitbox_core::KeyPart) it produces into a
+/// [`CacheTag`](hitbox_core::tag::CacheTag) of the form `"key=value"`.
+fn wrap_extractor<ReqBody>(
+    ext: Extractor,
+) -> Result<BoxTagExtractor<CacheableHttpRequest<ReqBody>>, ConfigError>
+where
+    ReqBody: hyper::body::Body + Send + Debug + 'static,
+    ReqBody::Error: Debug + Send,
+    ReqBody::Data: Send,
+{
+    let neutral: BoxExtractor<CacheableHttpRequest<ReqBody>> =
+        Box::new(NeutralExtractor::<ReqBody>::new());
+    let chained = ext.into_extractors(neutral)?;
+    Ok(Box::new(TagAdapter::new(chained)))
+}
+
+/// Build a boxed runtime tag extractor for the request side from a list
+/// of [`RequestTagExtractor`] config variants.
+///
+/// Multiple entries are composed via
+/// [`ChainTagExtractor`](hitbox_core::tag::ChainTagExtractor) at runtime —
+/// tags from each entry are concatenated in order.
+pub fn build_request_boxed<ReqBody>(
+    configs: Vec<RequestTagExtractor>,
+) -> Result<BoxTagExtractor<CacheableHttpRequest<ReqBody>>, ConfigError>
+where
+    ReqBody: hyper::body::Body + Send + Debug + 'static,
+    ReqBody::Error: Debug + Send,
+    ReqBody::Data: Send,
+{
+    let mut tag_extractors: Vec<BoxTagExtractor<CacheableHttpRequest<ReqBody>>> =
+        Vec::with_capacity(configs.len());
+    for cfg in configs {
+        tag_extractors.push(cfg.into_tag_extractor::<ReqBody>()?);
+    }
+    Ok(match tag_extractors.len() {
+        0 => Box::new(NeutralTagExtractor::<CacheableHttpRequest<ReqBody>>::default()),
+        1 => tag_extractors.into_iter().next().unwrap(),
+        _ => Box::new(ChainTagExtractor::new(tag_extractors)),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extractors::path::Path;
+    use indexmap::IndexMap;
+
+    #[test]
+    fn request_static_round_trips_via_yaml() {
+        let yaml = r#"
+            Static:
+              user: "42"
+        "#;
+        let parsed: RequestTagExtractor = serde_saphyr::from_str(yaml).unwrap();
+        let mut map = IndexMap::new();
+        map.insert("user".into(), "42".into());
+        assert_eq!(parsed, RequestTagExtractor::Static(Static::Map(map)));
+    }
+
+    #[test]
+    fn request_path_round_trips_via_yaml() {
+        let yaml = r#"Path: "/v1/authors/{author_id}/books/{book_id}""#;
+        let parsed: RequestTagExtractor = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(
+            parsed,
+            RequestTagExtractor::Path(Path::new("/v1/authors/{author_id}/books/{book_id}"))
+        );
+    }
+
+    #[test]
+    fn request_list_of_mixed_variants_round_trips() {
+        let yaml = r#"
+            - Static:
+                user: "42"
+            - Path: "/v1/authors/{author_id}"
+            - Method: {}
+        "#;
+        let parsed: Vec<RequestTagExtractor> = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(parsed.len(), 3);
+        assert!(matches!(parsed[0], RequestTagExtractor::Static(_)));
+        assert!(matches!(parsed[1], RequestTagExtractor::Path(_)));
+        assert!(matches!(parsed[2], RequestTagExtractor::Method(_)));
+    }
+}

--- a/hitbox-configuration/src/extractors/tag/request.rs
+++ b/hitbox-configuration/src/extractors/tag/request.rs
@@ -22,8 +22,8 @@
 use std::fmt::Debug;
 
 use hitbox::config::{BoxExtractor, BoxTagExtractor};
-use hitbox_core::tag::{ChainTagExtractor, ExtractorExt, NeutralTagExtractor, TagAdapter};
 use hitbox_core::StaticExtractor;
+use hitbox_core::tag::{ChainTagExtractor, ExtractorExt, NeutralTagExtractor, TagAdapter};
 use hitbox_http::CacheableHttpRequest;
 use hitbox_http::extractors::NeutralExtractor;
 use serde::{Deserialize, Serialize};
@@ -31,8 +31,8 @@ use serde::{Deserialize, Serialize};
 use super::Static;
 use crate::error::ConfigError;
 use crate::extractors::{
-    body::BodyOperation, header::HeaderOperation, method::Method, path::Path,
-    query::QueryOperation, version::Version, Extractor,
+    Extractor, body::BodyOperation, header::HeaderOperation, method::Method, path::Path,
+    query::QueryOperation, version::Version,
 };
 
 /// Request-side tag extractor configuration.

--- a/hitbox-core/src/config.rs
+++ b/hitbox-core/src/config.rs
@@ -8,11 +8,12 @@ use std::sync::Arc;
 use crate::Extractor;
 use crate::policy::PolicyConfig;
 use crate::predicate::Predicate;
+use crate::tag::TagExtractor;
 
 /// Trait for cache configuration.
 ///
 /// Provides predicates for determining cacheability, extractors for generating
-/// cache keys, and policy for TTL/staleness behavior.
+/// cache keys, tag extractors for invalidation, and policy for TTL/staleness behavior.
 pub trait CacheConfig<Req, Res> {
     /// Predicate type for filtering requests.
     type RequestPredicate: Predicate<Subject = Req> + Send + Sync + 'static;
@@ -20,6 +21,10 @@ pub trait CacheConfig<Req, Res> {
     type ResponsePredicate: Predicate<Subject = Res> + Send + Sync + 'static;
     /// Extractor type for generating cache keys.
     type Extractor: Extractor<Subject = Req> + Send + Sync + 'static;
+    /// Tag extractor type for deriving request-side cache tags.
+    type RequestTagExtractor: TagExtractor<Subject = Req> + Send + Sync + 'static;
+    /// Tag extractor type for deriving response-side cache tags.
+    type ResponseTagExtractor: TagExtractor<Subject = Res> + Send + Sync + 'static;
 
     /// Returns predicates that decide if a request should be cached.
     fn request_predicates(&self) -> Self::RequestPredicate;
@@ -27,6 +32,10 @@ pub trait CacheConfig<Req, Res> {
     fn response_predicates(&self) -> Self::ResponsePredicate;
     /// Returns extractors that generate cache keys from requests.
     fn extractors(&self) -> Self::Extractor;
+    /// Returns tag extractors that derive cache tags from requests.
+    fn request_tag_extractors(&self) -> Self::RequestTagExtractor;
+    /// Returns tag extractors that derive cache tags from responses.
+    fn response_tag_extractors(&self) -> Self::ResponseTagExtractor;
     /// Returns TTL and behavior policy for cached entries.
     fn policy(&self) -> Arc<PolicyConfig>;
 }
@@ -51,6 +60,8 @@ where
     type RequestPredicate = T::RequestPredicate;
     type ResponsePredicate = T::ResponsePredicate;
     type Extractor = T::Extractor;
+    type RequestTagExtractor = T::RequestTagExtractor;
+    type ResponseTagExtractor = T::ResponseTagExtractor;
 
     fn request_predicates(&self) -> Self::RequestPredicate {
         self.as_ref().request_predicates()
@@ -62,6 +73,14 @@ where
 
     fn extractors(&self) -> Self::Extractor {
         self.as_ref().extractors()
+    }
+
+    fn request_tag_extractors(&self) -> Self::RequestTagExtractor {
+        self.as_ref().request_tag_extractors()
+    }
+
+    fn response_tag_extractors(&self) -> Self::ResponseTagExtractor {
+        self.as_ref().response_tag_extractors()
     }
 
     fn policy(&self) -> Arc<PolicyConfig> {

--- a/hitbox-core/src/extractor.rs
+++ b/hitbox-core/src/extractor.rs
@@ -35,11 +35,12 @@
 //! }
 //! ```
 
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::KeyParts;
+use crate::{KeyPart, KeyParts};
 
 /// Trait for extracting cache key components from a subject.
 ///
@@ -112,5 +113,134 @@ where
 
     async fn get(&self, subject: T::Subject) -> KeyParts<T::Subject> {
         self.as_ref().get(subject).await
+    }
+}
+
+/// Extractor that emits a fixed list of [`KeyPart`]s regardless of subject.
+///
+/// Useful for embedding constant data in cache keys — environment markers,
+/// service identifiers, deployment tags — and, when wrapped via
+/// [`ExtractorExt::as_tag`](crate::tag::ExtractorExt::as_tag), for
+/// constant-tag invalidation namespaces.
+///
+/// `Subject` is a phantom slot — the extractor never inspects the subject.
+/// The `PhantomData<fn() -> S>` variance keeps `StaticExtractor<S>` `Send + Sync`
+/// even when `S` isn't.
+///
+/// # Examples
+///
+/// As a key extractor:
+/// ```ignore
+/// use hitbox_core::{Extractor, KeyPart, StaticExtractor};
+///
+/// let ext = StaticExtractor::<()>::new(vec![
+///     KeyPart::new("env", Some("prod")),
+///     KeyPart::new("region", Some("eu-west-1")),
+/// ]);
+/// ```
+///
+/// As a tag extractor (via `as_tag`):
+/// ```ignore
+/// use hitbox_core::{KeyPart, StaticExtractor};
+/// use hitbox_core::tag::ExtractorExt;
+///
+/// // Each KeyPart becomes a `"key=value"` CacheTag.
+/// let tag_ext = StaticExtractor::<()>::new(vec![
+///     KeyPart::new("user", Some("42")),
+///     KeyPart::new("region", Some("eu")),
+/// ]).as_tag();
+/// ```
+pub struct StaticExtractor<S> {
+    parts: Vec<KeyPart>,
+    _phantom: PhantomData<fn() -> S>,
+}
+
+impl<S> StaticExtractor<S> {
+    /// Create a static extractor that emits `parts` for every subject.
+    pub fn new(parts: Vec<KeyPart>) -> Self {
+        Self {
+            parts,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<S> Default for StaticExtractor<S> {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+impl<S> std::fmt::Debug for StaticExtractor<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StaticExtractor")
+            .field("parts", &self.parts)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl<S> Extractor for StaticExtractor<S>
+where
+    S: Send,
+{
+    type Subject = S;
+
+    async fn get(&self, subject: S) -> KeyParts<S> {
+        let mut key_parts = KeyParts::new(subject);
+        for part in &self.parts {
+            key_parts.push(part.clone());
+        }
+        key_parts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tag::ExtractorExt;
+
+    #[tokio::test]
+    async fn static_extractor_emits_configured_parts() {
+        let ext = StaticExtractor::<u32>::new(vec![
+            KeyPart::new("env", Some("prod")),
+            KeyPart::new("region", Some("eu")),
+        ]);
+
+        let key_parts = ext.get(7).await;
+        let (subject, key) = key_parts.into_cache_key();
+
+        assert_eq!(subject, 7);
+        let parts: Vec<_> = key.parts().collect();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0].key(), "env");
+        assert_eq!(parts[0].value(), Some("prod"));
+        assert_eq!(parts[1].key(), "region");
+        assert_eq!(parts[1].value(), Some("eu"));
+    }
+
+    #[tokio::test]
+    async fn static_extractor_default_emits_no_parts() {
+        let ext = StaticExtractor::<u32>::default();
+        let key_parts = ext.get(0).await;
+        let (_subject, key) = key_parts.into_cache_key();
+        assert_eq!(key.parts().count(), 0);
+    }
+
+    #[tokio::test]
+    async fn static_extractor_via_as_tag_yields_key_value_tags() {
+        // KeyPart with Some value → CacheTag is "key=value".
+        let tag_ext = StaticExtractor::<u32>::new(vec![
+            KeyPart::new("user", Some("42")),
+            KeyPart::new("region", Some("eu")),
+        ])
+        .as_tag();
+
+        use crate::tag::TagExtractor;
+        let (subject, tags) = tag_ext.extract_tags(123).await;
+        assert_eq!(subject, 123);
+        assert_eq!(tags.len(), 2);
+        assert_eq!(tags[0].as_str(), "user=42");
+        assert_eq!(tags[1].as_str(), "region=eu");
     }
 }

--- a/hitbox-core/src/lib.rs
+++ b/hitbox-core/src/lib.rs
@@ -28,21 +28,21 @@ pub use label::BackendLabel;
 pub use offload::{DisabledOffload, Offload, OffloadKey};
 pub use policy::{
     CacheBehaviorPolicy, CachePolicy, ConcurrencyLimit, EnabledCacheConfig, EntityPolicyConfig,
-    PolicyConfig, PolicyConfigBuilder, StalePolicy,
+    PolicyConfig, PolicyConfigBuilder, StalePolicy, TagInvalidation,
 };
 pub use predicate::{And, Neutral, Not, Or, Predicate, PredicateExt, PredicateResult};
 pub use request::{CacheablePolicyData, CacheableRequest, RequestCachePolicy};
 pub use response::{CacheState, CacheableResponse, ResponseCachePolicy};
-pub use tag::{
-    CacheTag, CacheTags, ChainTagExtractor, ExtractorExt, NeutralTagExtractor, TagAdapter,
-    TagExtractor,
-};
 #[doc(hidden)]
 pub use serde;
 #[doc(hidden)]
 pub use smallbox::space::S4;
 #[doc(hidden)]
 pub use smol_str::SmolStr;
+pub use tag::{
+    CacheTag, CacheTags, ChainTagExtractor, ExtractorExt, NeutralTagExtractor, TagAdapter,
+    TagExtractor,
+};
 pub use upstream::Upstream;
 pub use value::CacheValue;
 

--- a/hitbox-core/src/lib.rs
+++ b/hitbox-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod policy;
 pub mod predicate;
 pub mod request;
 pub mod response;
+pub mod tag;
 pub mod upstream;
 pub mod value;
 
@@ -21,7 +22,7 @@ pub use context::{
     BoxContext, CacheContext, CacheStatus, CacheStatusExt, Context, ReadMode, ResponseSource,
     finalize_context,
 };
-pub use extractor::Extractor;
+pub use extractor::{Extractor, StaticExtractor};
 pub use key::{CacheKey, KeyPart, KeyParts};
 pub use label::BackendLabel;
 pub use offload::{DisabledOffload, Offload, OffloadKey};
@@ -32,6 +33,10 @@ pub use policy::{
 pub use predicate::{And, Neutral, Not, Or, Predicate, PredicateExt, PredicateResult};
 pub use request::{CacheablePolicyData, CacheableRequest, RequestCachePolicy};
 pub use response::{CacheState, CacheableResponse, ResponseCachePolicy};
+pub use tag::{
+    CacheTag, CacheTags, ChainTagExtractor, ExtractorExt, NeutralTagExtractor, TagAdapter,
+    TagExtractor,
+};
 #[doc(hidden)]
 pub use serde;
 #[doc(hidden)]

--- a/hitbox-core/src/policy.rs
+++ b/hitbox-core/src/policy.rs
@@ -115,6 +115,36 @@ pub enum StalePolicy {
     OffloadRevalidate,
 }
 
+/// Whether tag-based invalidation runs at all.
+///
+/// Gates **both** sides end to end: tag extraction at write time and the
+/// invalidation timestamp queries/comparison at read time. When
+/// [`Skip`](TagInvalidation::Skip), no tag extractor future is constructed
+/// (the heavy request-body / response-body / JQ work never runs) and no
+/// `invalidated()` backend round-trips are issued.
+///
+/// [`Backend::invalidate`] still records timestamps when called explicitly,
+/// so flipping back to [`Check`](TagInvalidation::Check) is safe:
+/// request-side invalidation resumes immediately (request tags are
+/// re-derived on read), response-side self-heals within one TTL (entries
+/// written during `Skip` carry no response tags until they expire and
+/// refill).
+///
+/// [`Backend::invalidate`]: https://docs.rs/hitbox-backend
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+pub enum TagInvalidation {
+    /// Extract tags on write and consult invalidation timestamps on read
+    /// (default).
+    #[default]
+    Check,
+    /// Skip tag extraction and the read-time invalidation check entirely.
+    ///
+    /// Operational safety valve (clock skew / flaky tag store causing
+    /// false invalidations), latency/cost control (tag extraction can be
+    /// heavy; the read check adds backend round-trips), or staged rollout.
+    Skip,
+}
+
 /// Cache behavior policy configuration.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct CacheBehaviorPolicy {
@@ -135,6 +165,8 @@ pub struct EnabledCacheConfig {
     pub policy: CacheBehaviorPolicy,
     /// Concurrency limit for dogpile prevention.
     pub concurrency: Option<ConcurrencyLimit>,
+    /// Whether tag-based invalidation runs (extraction + read check).
+    pub tag_invalidation: TagInvalidation,
 }
 
 impl Default for EnabledCacheConfig {
@@ -144,6 +176,7 @@ impl Default for EnabledCacheConfig {
             stale: None,
             policy: CacheBehaviorPolicy::default(),
             concurrency: None,
+            tag_invalidation: TagInvalidation::default(),
         }
     }
 }
@@ -175,6 +208,21 @@ impl PolicyConfig {
     pub fn disabled() -> Self {
         Self::Disabled
     }
+
+    /// Whether the FSM should run tag-based invalidation (tag extraction
+    /// on write and the invalidation timestamp check on read).
+    ///
+    /// `false` when caching is disabled (no cache reads happen anyway) or
+    /// when the enabled config selects [`TagInvalidation::Skip`].
+    pub fn tag_invalidation_enabled(&self) -> bool {
+        matches!(
+            self,
+            PolicyConfig::Enabled(EnabledCacheConfig {
+                tag_invalidation: TagInvalidation::Check,
+                ..
+            })
+        )
+    }
 }
 
 /// Builder for [`PolicyConfig`].
@@ -184,6 +232,7 @@ pub struct PolicyConfigBuilder {
     stale: Option<Duration>,
     stale_policy: StalePolicy,
     concurrency: Option<ConcurrencyLimit>,
+    tag_invalidation: TagInvalidation,
 }
 
 impl PolicyConfigBuilder {
@@ -224,6 +273,15 @@ impl PolicyConfigBuilder {
         }
     }
 
+    /// Set whether tag-based invalidation runs (default
+    /// [`TagInvalidation::Check`]).
+    pub fn tag_invalidation(self, tag_invalidation: TagInvalidation) -> Self {
+        Self {
+            tag_invalidation,
+            ..self
+        }
+    }
+
     /// Build the [`PolicyConfig`] with enabled caching.
     pub fn build(self) -> PolicyConfig {
         PolicyConfig::Enabled(EnabledCacheConfig {
@@ -233,6 +291,7 @@ impl PolicyConfigBuilder {
                 stale: self.stale_policy,
             },
             concurrency: self.concurrency,
+            tag_invalidation: self.tag_invalidation,
         })
     }
 }

--- a/hitbox-core/src/request.rs
+++ b/hitbox-core/src/request.rs
@@ -69,9 +69,8 @@ pub trait CacheableRequest: Sized {
     ///
     /// Uses GAT to properly capture the lifetime of `Self`, allowing
     /// request types with non-`'static` references.
-    type CachePolicyFuture<'a, P, E, TE>: Future<
-            Output = (RequestCachePolicy<Self>, Vec<CacheTag>),
-        > + Send
+    type CachePolicyFuture<'a, P, E, TE>: Future<Output = (RequestCachePolicy<Self>, Vec<CacheTag>)>
+        + Send
         + 'a
     where
         Self: 'a,
@@ -80,21 +79,26 @@ pub trait CacheableRequest: Sized {
         TE: TagExtractor<Subject = Self> + Send + Sync + 'a;
 
     /// Determine if this request should be cached, extract its key, and
-    /// extract request-side cache tags.
+    /// (optionally) extract request-side cache tags.
     ///
-    /// Tag extraction runs only when the request is cacheable. For
-    /// non-cacheable requests, an empty tag list is returned.
+    /// Tag extraction runs only when the request is cacheable **and**
+    /// `tag_extractor` is `Some`. When it is `None`, no extractor future is
+    /// constructed at all (used to skip extraction entirely via
+    /// [`TagInvalidation::Skip`](crate::policy::TagInvalidation)); the
+    /// returned tag list is empty. Non-cacheable requests also yield an
+    /// empty tag list.
     ///
     /// # Arguments
     ///
     /// * `predicates` - Predicates to evaluate whether the request is cacheable
     /// * `extractors` - Extractors to generate the cache key
-    /// * `tag_extractor` - Extractor for request-side cache tags
+    /// * `tag_extractor` - Optional extractor for request-side cache tags;
+    ///   `None` skips tag extraction
     fn cache_policy<'a, P, E, TE>(
         self,
         predicates: P,
         extractors: E,
-        tag_extractor: TE,
+        tag_extractor: Option<TE>,
     ) -> Self::CachePolicyFuture<'a, P, E, TE>
     where
         Self: 'a,

--- a/hitbox-core/src/request.rs
+++ b/hitbox-core/src/request.rs
@@ -17,7 +17,10 @@
 
 use std::future::Future;
 
-use crate::{CacheKey, CachePolicy, extractor::Extractor, predicate::Predicate};
+use crate::{
+    CacheKey, CachePolicy, extractor::Extractor, predicate::Predicate, tag::CacheTag,
+    tag::TagExtractor,
+};
 
 /// A cacheable request bundled with its generated cache key.
 ///
@@ -66,25 +69,36 @@ pub trait CacheableRequest: Sized {
     ///
     /// Uses GAT to properly capture the lifetime of `Self`, allowing
     /// request types with non-`'static` references.
-    type CachePolicyFuture<'a, P, E>: Future<Output = RequestCachePolicy<Self>> + Send + 'a
+    type CachePolicyFuture<'a, P, E, TE>: Future<
+            Output = (RequestCachePolicy<Self>, Vec<CacheTag>),
+        > + Send
+        + 'a
     where
         Self: 'a,
         P: Predicate<Subject = Self> + Send + Sync + 'a,
-        E: Extractor<Subject = Self> + Send + Sync + 'a;
+        E: Extractor<Subject = Self> + Send + Sync + 'a,
+        TE: TagExtractor<Subject = Self> + Send + Sync + 'a;
 
-    /// Determine if this request should be cached and extract its key.
+    /// Determine if this request should be cached, extract its key, and
+    /// extract request-side cache tags.
+    ///
+    /// Tag extraction runs only when the request is cacheable. For
+    /// non-cacheable requests, an empty tag list is returned.
     ///
     /// # Arguments
     ///
     /// * `predicates` - Predicates to evaluate whether the request is cacheable
     /// * `extractors` - Extractors to generate the cache key
-    fn cache_policy<'a, P, E>(
+    /// * `tag_extractor` - Extractor for request-side cache tags
+    fn cache_policy<'a, P, E, TE>(
         self,
         predicates: P,
         extractors: E,
-    ) -> Self::CachePolicyFuture<'a, P, E>
+        tag_extractor: TE,
+    ) -> Self::CachePolicyFuture<'a, P, E, TE>
     where
         Self: 'a,
         P: Predicate<Subject = Self> + Send + Sync + 'a,
-        E: Extractor<Subject = Self> + Send + Sync + 'a;
+        E: Extractor<Subject = Self> + Send + Sync + 'a,
+        TE: TagExtractor<Subject = Self> + Send + Sync + 'a;
 }

--- a/hitbox-core/src/response.rs
+++ b/hitbox-core/src/response.rs
@@ -34,7 +34,6 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use chrono::Utc;
 use pin_project::pin_project;
 
 use crate::{
@@ -93,8 +92,8 @@ pub enum CacheState<Cached> {
 /// use hitbox_core::{CacheableResponse, CachePolicy, EntityPolicyConfig};
 /// use hitbox_core::predicate::{Predicate, PredicateResult};
 /// use hitbox_core::response::ResponseCachePolicy;
+/// use hitbox_core::tag::{CacheTag, TagExtractor};
 /// use hitbox_core::value::CacheValue;
-/// use chrono::Utc;
 ///
 /// #[derive(Clone)]
 /// struct MyResponse {
@@ -108,24 +107,28 @@ pub enum CacheState<Cached> {
 ///     type IntoCachedFuture = std::future::Ready<CachePolicy<String, Self>>;
 ///     type FromCachedFuture = std::future::Ready<Self>;
 ///
-///     async fn cache_policy<P>(
+///     async fn cache_policy<P, TE>(
 ///         self,
 ///         predicates: P,
+///         tag_extractor: TE,
 ///         config: &EntityPolicyConfig,
-///     ) -> ResponseCachePolicy<Self>
+///     ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
 ///     where
 ///         P: Predicate<Subject = Self::Subject> + Send + Sync,
+///         TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
 ///     {
 ///         match predicates.check(self).await {
 ///             PredicateResult::Cacheable(data) => {
+///                 let (data, tags) = tag_extractor.extract_tags(data).await;
 ///                 let cached = data.body.clone();
-///                 CachePolicy::Cacheable(CacheValue::new(
-///                     cached,
-///                     config.ttl.map(|d| Utc::now() + d),
-///                     config.stale_ttl.map(|d| Utc::now() + d),
-///                 ))
+///                 (
+///                     CachePolicy::Cacheable(CacheValue::from_config(cached, config)),
+///                     tags,
+///                 )
 ///             }
-///             PredicateResult::NonCacheable(data) => CachePolicy::NonCacheable(data),
+///             PredicateResult::NonCacheable(data) => {
+///                 (CachePolicy::NonCacheable(data), Vec::new())
+///             }
 ///         }
 ///     }
 ///
@@ -158,22 +161,29 @@ where
     /// Future type for `from_cached` method.
     type FromCachedFuture: Future<Output = Self> + Send;
 
-    /// Determine if this response should be cached.
+    /// Determine if this response should be cached and extract response tags.
     ///
-    /// Applies predicates to determine cacheability, then converts cacheable
-    /// responses to their cached representation with TTL metadata.
+    /// Applies predicates to determine cacheability, runs the response tag
+    /// extractor (when cacheable), and converts cacheable responses to their
+    /// cached representation with TTL metadata.
+    ///
+    /// Tag extraction runs on `Self::Subject` — the same value the predicate
+    /// checked. For non-cacheable responses, an empty tag list is returned.
     ///
     /// # Arguments
     ///
     /// * `predicates` - Predicates to evaluate whether the response is cacheable
+    /// * `tag_extractor` - Extractor for response-side cache tags
     /// * `config` - TTL configuration for the cached entry
-    fn cache_policy<P>(
+    fn cache_policy<P, TE>(
         self,
         predicates: P,
+        tag_extractor: TE,
         config: &EntityPolicyConfig,
-    ) -> impl Future<Output = ResponseCachePolicy<Self>> + Send
+    ) -> impl Future<Output = (ResponseCachePolicy<Self>, Vec<crate::tag::CacheTag>)> + Send
     where
-        P: Predicate<Subject = Self::Subject> + Send + Sync;
+        P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: crate::tag::TagExtractor<Subject = Self::Subject> + Send + Sync;
 
     /// Convert this response to its cached representation.
     ///
@@ -200,24 +210,28 @@ macro_rules! impl_cacheable_response_for_scalar {
                 type IntoCachedFuture = std::future::Ready<CachePolicy<Self, Self>>;
                 type FromCachedFuture = std::future::Ready<Self>;
 
-                async fn cache_policy<P>(
+                async fn cache_policy<P, TE>(
                     self,
                     predicates: P,
+                    tag_extractor: TE,
                     config: &EntityPolicyConfig,
-                ) -> ResponseCachePolicy<Self>
+                ) -> (ResponseCachePolicy<Self>, Vec<crate::tag::CacheTag>)
                 where
                     P: Predicate<Subject = Self::Subject> + Send + Sync,
+                    TE: crate::tag::TagExtractor<Subject = Self::Subject> + Send + Sync,
                 {
                     match predicates.check(self).await {
                         PredicateResult::Cacheable(data) => {
+                            let (data, tags) = tag_extractor.extract_tags(data).await;
                             let cached = data.clone();
-                            CachePolicy::Cacheable(CacheValue::new(
-                                cached,
-                                config.ttl.map(|d| Utc::now() + d),
-                                config.stale_ttl.map(|d| Utc::now() + d),
-                            ))
+                            (
+                                CachePolicy::Cacheable(CacheValue::from_config(cached, config)),
+                                tags,
+                            )
                         }
-                        PredicateResult::NonCacheable(data) => CachePolicy::NonCacheable(data),
+                        PredicateResult::NonCacheable(data) => {
+                            (CachePolicy::NonCacheable(data), Vec::new())
+                        }
                     }
                 }
 
@@ -257,24 +271,28 @@ where
     type IntoCachedFuture = std::future::Ready<CachePolicy<Self, Self>>;
     type FromCachedFuture = std::future::Ready<Self>;
 
-    async fn cache_policy<P>(
+    async fn cache_policy<P, TE>(
         self,
         predicates: P,
+        tag_extractor: TE,
         config: &EntityPolicyConfig,
-    ) -> ResponseCachePolicy<Self>
+    ) -> (ResponseCachePolicy<Self>, Vec<crate::tag::CacheTag>)
     where
         P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: crate::tag::TagExtractor<Subject = Self::Subject> + Send + Sync,
     {
         match predicates.check(self).await {
             PredicateResult::Cacheable(data) => {
+                let (data, tags) = tag_extractor.extract_tags(data).await;
                 let cached = data.clone();
-                CachePolicy::Cacheable(CacheValue::new(
-                    cached,
-                    config.ttl.map(|d| Utc::now() + d),
-                    config.stale_ttl.map(|d| Utc::now() + d),
-                ))
+                (
+                    CachePolicy::Cacheable(CacheValue::from_config(cached, config)),
+                    tags,
+                )
             }
-            PredicateResult::NonCacheable(data) => CachePolicy::NonCacheable(data),
+            PredicateResult::NonCacheable(data) => {
+                (CachePolicy::NonCacheable(data), Vec::new())
+            }
         }
     }
 
@@ -359,27 +377,38 @@ where
     type IntoCachedFuture = ResultIntoCachedFuture<T, E>;
     type FromCachedFuture = ResultFromCachedFuture<T, E>;
 
-    async fn cache_policy<P>(
+    async fn cache_policy<P, TE>(
         self,
         predicates: P,
+        tag_extractor: TE,
         config: &EntityPolicyConfig,
-    ) -> ResponseCachePolicy<Self>
+    ) -> (ResponseCachePolicy<Self>, Vec<crate::tag::CacheTag>)
     where
         P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: crate::tag::TagExtractor<Subject = Self::Subject> + Send + Sync,
     {
         match self {
             Ok(response) => match predicates.check(response).await {
-                PredicateResult::Cacheable(cacheable) => match cacheable.into_cached().await {
-                    CachePolicy::Cacheable(res) => CachePolicy::Cacheable(CacheValue::new(
-                        res,
-                        config.ttl.map(|duration| Utc::now() + duration),
-                        config.stale_ttl.map(|duration| Utc::now() + duration),
-                    )),
-                    CachePolicy::NonCacheable(res) => CachePolicy::NonCacheable(Ok(res)),
-                },
-                PredicateResult::NonCacheable(res) => CachePolicy::NonCacheable(Ok(res)),
+                PredicateResult::Cacheable(cacheable) => {
+                    let (cacheable, tags) = tag_extractor.extract_tags(cacheable).await;
+                    match cacheable.into_cached().await {
+                        CachePolicy::Cacheable(res) => (
+                            CachePolicy::Cacheable(CacheValue::from_config(res, config)),
+                            tags,
+                        ),
+                        CachePolicy::NonCacheable(res) => {
+                            (CachePolicy::NonCacheable(Ok(res)), tags)
+                        }
+                    }
+                }
+                PredicateResult::NonCacheable(res) => {
+                    (CachePolicy::NonCacheable(Ok(res)), Vec::new())
+                }
             },
-            Err(error) => ResponseCachePolicy::NonCacheable(Err(error)),
+            Err(error) => (
+                ResponseCachePolicy::NonCacheable(Err(error)),
+                Vec::new(),
+            ),
         }
     }
 

--- a/hitbox-core/src/response.rs
+++ b/hitbox-core/src/response.rs
@@ -110,7 +110,7 @@ pub enum CacheState<Cached> {
 ///     async fn cache_policy<P, TE>(
 ///         self,
 ///         predicates: P,
-///         tag_extractor: TE,
+///         tag_extractor: Option<TE>,
 ///         config: &EntityPolicyConfig,
 ///     ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
 ///     where
@@ -119,7 +119,10 @@ pub enum CacheState<Cached> {
 ///     {
 ///         match predicates.check(self).await {
 ///             PredicateResult::Cacheable(data) => {
-///                 let (data, tags) = tag_extractor.extract_tags(data).await;
+///                 let (data, tags) = match tag_extractor {
+///                     Some(te) => te.extract_tags(data).await,
+///                     None => (data, Vec::new()),
+///                 };
 ///                 let cached = data.body.clone();
 ///                 (
 ///                     CachePolicy::Cacheable(CacheValue::from_config(cached, config)),
@@ -161,24 +164,28 @@ where
     /// Future type for `from_cached` method.
     type FromCachedFuture: Future<Output = Self> + Send;
 
-    /// Determine if this response should be cached and extract response tags.
+    /// Determine if this response should be cached and (optionally) extract
+    /// response tags.
     ///
-    /// Applies predicates to determine cacheability, runs the response tag
-    /// extractor (when cacheable), and converts cacheable responses to their
-    /// cached representation with TTL metadata.
-    ///
-    /// Tag extraction runs on `Self::Subject` — the same value the predicate
-    /// checked. For non-cacheable responses, an empty tag list is returned.
+    /// Applies predicates to determine cacheability and converts cacheable
+    /// responses to their cached representation with TTL metadata. The
+    /// response tag extractor runs only when the response is cacheable
+    /// **and** `tag_extractor` is `Some`. When it is `None`, no extractor
+    /// future is constructed (used to skip extraction entirely via
+    /// [`TagInvalidation::Skip`](crate::policy::TagInvalidation)); the
+    /// returned tag list is empty. Non-cacheable responses also yield an
+    /// empty tag list.
     ///
     /// # Arguments
     ///
     /// * `predicates` - Predicates to evaluate whether the response is cacheable
-    /// * `tag_extractor` - Extractor for response-side cache tags
+    /// * `tag_extractor` - Optional extractor for response-side cache tags;
+    ///   `None` skips tag extraction
     /// * `config` - TTL configuration for the cached entry
     fn cache_policy<P, TE>(
         self,
         predicates: P,
-        tag_extractor: TE,
+        tag_extractor: Option<TE>,
         config: &EntityPolicyConfig,
     ) -> impl Future<Output = (ResponseCachePolicy<Self>, Vec<crate::tag::CacheTag>)> + Send
     where
@@ -213,7 +220,7 @@ macro_rules! impl_cacheable_response_for_scalar {
                 async fn cache_policy<P, TE>(
                     self,
                     predicates: P,
-                    tag_extractor: TE,
+                    tag_extractor: Option<TE>,
                     config: &EntityPolicyConfig,
                 ) -> (ResponseCachePolicy<Self>, Vec<crate::tag::CacheTag>)
                 where
@@ -222,7 +229,10 @@ macro_rules! impl_cacheable_response_for_scalar {
                 {
                     match predicates.check(self).await {
                         PredicateResult::Cacheable(data) => {
-                            let (data, tags) = tag_extractor.extract_tags(data).await;
+                            let (data, tags) = match tag_extractor {
+                    Some(te) => te.extract_tags(data).await,
+                    None => (data, Vec::new()),
+                };
                             let cached = data.clone();
                             (
                                 CachePolicy::Cacheable(CacheValue::from_config(cached, config)),
@@ -274,7 +284,7 @@ where
     async fn cache_policy<P, TE>(
         self,
         predicates: P,
-        tag_extractor: TE,
+        tag_extractor: Option<TE>,
         config: &EntityPolicyConfig,
     ) -> (ResponseCachePolicy<Self>, Vec<crate::tag::CacheTag>)
     where
@@ -283,16 +293,17 @@ where
     {
         match predicates.check(self).await {
             PredicateResult::Cacheable(data) => {
-                let (data, tags) = tag_extractor.extract_tags(data).await;
+                let (data, tags) = match tag_extractor {
+                    Some(te) => te.extract_tags(data).await,
+                    None => (data, Vec::new()),
+                };
                 let cached = data.clone();
                 (
                     CachePolicy::Cacheable(CacheValue::from_config(cached, config)),
                     tags,
                 )
             }
-            PredicateResult::NonCacheable(data) => {
-                (CachePolicy::NonCacheable(data), Vec::new())
-            }
+            PredicateResult::NonCacheable(data) => (CachePolicy::NonCacheable(data), Vec::new()),
         }
     }
 
@@ -380,7 +391,7 @@ where
     async fn cache_policy<P, TE>(
         self,
         predicates: P,
-        tag_extractor: TE,
+        tag_extractor: Option<TE>,
         config: &EntityPolicyConfig,
     ) -> (ResponseCachePolicy<Self>, Vec<crate::tag::CacheTag>)
     where
@@ -390,7 +401,10 @@ where
         match self {
             Ok(response) => match predicates.check(response).await {
                 PredicateResult::Cacheable(cacheable) => {
-                    let (cacheable, tags) = tag_extractor.extract_tags(cacheable).await;
+                    let (cacheable, tags) = match tag_extractor {
+                        Some(te) => te.extract_tags(cacheable).await,
+                        None => (cacheable, Vec::new()),
+                    };
                     match cacheable.into_cached().await {
                         CachePolicy::Cacheable(res) => (
                             CachePolicy::Cacheable(CacheValue::from_config(res, config)),
@@ -405,10 +419,7 @@ where
                     (CachePolicy::NonCacheable(Ok(res)), Vec::new())
                 }
             },
-            Err(error) => (
-                ResponseCachePolicy::NonCacheable(Err(error)),
-                Vec::new(),
-            ),
+            Err(error) => (ResponseCachePolicy::NonCacheable(Err(error)), Vec::new()),
         }
     }
 

--- a/hitbox-core/src/tag.rs
+++ b/hitbox-core/src/tag.rs
@@ -1,0 +1,425 @@
+//! Cache tag types for group invalidation.
+//!
+//! This module provides types for tagging cached entries and extracting tags:
+//!
+//! - [`CacheTag`] - A single cache tag for group invalidation
+//! - [`CacheTags`] - Request and response tags stored with a cache entry
+//! - [`TagExtractor`] - Trait for deriving tags from requests or responses
+//! - [`TagAdapter`] - Adapter to reuse any [`Extractor`] as a [`TagExtractor`]
+//!
+//! ## Tag-Based Invalidation
+//!
+//! Tags allow invalidating groups of cache entries without knowing their exact keys.
+//! For example, tagging all entries related to a user allows invalidating them all
+//! when the user's data changes:
+//!
+//! ```
+//! use hitbox_core::tag::CacheTag;
+//!
+//! let tag = CacheTag::new("user:42");
+//! assert_eq!(tag.as_str(), "user:42");
+//! ```
+//!
+//! ## Tag Extraction
+//!
+//! Tags can be derived from requests (known before cache read, enabling parallel
+//! prefetch) or from responses (stored in the cache entry for post-read checks).
+//!
+//! Existing [`Extractor`] implementations can be reused as tag extractors via
+//! [`TagAdapter`], which converts [`KeyPart`]s into [`CacheTag`]s.
+//!
+//! [`Extractor`]: crate::Extractor
+//! [`KeyPart`]: crate::KeyPart
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use smol_str::SmolStr;
+
+use crate::Extractor;
+use crate::key::{CacheKey, KeyPart};
+
+/// A cache tag for group invalidation.
+///
+/// Tags are lightweight string identifiers associated with cache entries.
+/// Invalidating a tag marks all entries with that tag as stale.
+///
+/// Uses [`SmolStr`] internally for small string optimization — tags up to
+/// 23 bytes are stored inline without heap allocation.
+///
+/// # Example
+///
+/// ```
+/// use hitbox_core::tag::CacheTag;
+///
+/// let tag = CacheTag::new("user:42");
+/// assert_eq!(tag.as_str(), "user:42");
+///
+/// // Tags can be compared
+/// assert_eq!(CacheTag::new("user:42"), CacheTag::new("user:42"));
+/// assert_ne!(CacheTag::new("user:42"), CacheTag::new("user:43"));
+/// ```
+#[derive(Clone, Debug, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct CacheTag(SmolStr);
+
+impl CacheTag {
+    /// Creates a new cache tag.
+    pub fn new(tag: impl Into<SmolStr>) -> Self {
+        CacheTag(tag.into())
+    }
+
+    /// Returns the tag as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Converts this tag into a [`CacheKey`] for storing invalidation timestamps.
+    ///
+    /// Uses the given prefix as the key namespace. The tag value is stored
+    /// as a key part.
+    /// Converts this tag into a [`CacheKey`](crate::CacheKey) for storing
+    /// invalidation timestamps.
+    pub fn to_cache_key(&self, prefix: &str) -> CacheKey {
+        CacheKey::new(prefix, 0, vec![KeyPart::new("tag", Some(self.as_str()))])
+    }
+}
+
+impl std::fmt::Display for CacheTag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<&crate::KeyPart> for CacheTag {
+    /// Converts a [`KeyPart`](crate::KeyPart) into a [`CacheTag`].
+    ///
+    /// Format: `"key=value"` or `"key"` (if value is `None`).
+    fn from(part: &crate::KeyPart) -> Self {
+        match part.value() {
+            Some(value) => CacheTag::new(format!("{}={}", part.key(), value)),
+            None => CacheTag::new(part.key()),
+        }
+    }
+}
+
+/// Request and response tags stored with a cache entry.
+///
+/// Each side is `Option<Vec<CacheTag>>` so we can distinguish:
+/// - `None`: tag extractor was not configured for this side
+/// - `Some(vec![])`: extractor ran, produced no tags
+/// - `Some(vec![...])`: extractor produced tags
+///
+/// This matters for forensics / drift detection — empty vs unconfigured are
+/// different states. For invalidation correctness, both encodings produce
+/// the same behavior.
+#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct CacheTags {
+    /// Tags derived from the request at write time.
+    pub request: Option<Vec<CacheTag>>,
+    /// Tags derived from the response at write time.
+    pub response: Option<Vec<CacheTag>>,
+}
+
+impl CacheTags {
+    /// Creates empty tags (both sides `None`).
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Creates `CacheTags` with both request and response tag lists.
+    pub fn new(request: Vec<CacheTag>, response: Vec<CacheTag>) -> Self {
+        Self {
+            request: Some(request),
+            response: Some(response),
+        }
+    }
+
+    /// Creates `CacheTags` with only request tags configured.
+    pub fn request_only(request: Vec<CacheTag>) -> Self {
+        Self {
+            request: Some(request),
+            response: None,
+        }
+    }
+
+    /// Creates `CacheTags` with only response tags configured.
+    pub fn response_only(response: Vec<CacheTag>) -> Self {
+        Self {
+            request: None,
+            response: Some(response),
+        }
+    }
+
+    /// Returns true if neither side has any tag info (both `None` or empty).
+    pub fn is_empty(&self) -> bool {
+        self.request.as_ref().is_none_or(Vec::is_empty)
+            && self.response.as_ref().is_none_or(Vec::is_empty)
+    }
+}
+
+/// Trait for extracting cache tags from a subject.
+///
+/// Mirrors the [`Extractor`] trait: async, takes ownership of the subject,
+/// and returns it alongside the extracted tags. This allows tag extractors
+/// to consume request/response bodies if needed (e.g., JQ body extraction).
+///
+/// [`Extractor`]: crate::Extractor
+///
+/// # Example
+///
+/// ```ignore
+/// use hitbox_core::tag::{CacheTag, TagExtractor};
+///
+/// struct UserTagExtractor;
+///
+/// #[async_trait::async_trait]
+/// impl TagExtractor for UserTagExtractor {
+///     type Subject = u64;
+///
+///     async fn extract_tags(&self, user_id: u64) -> (u64, Vec<CacheTag>) {
+///         (user_id, vec![CacheTag::new(format!("user:{user_id}"))])
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait TagExtractor {
+    /// The type from which tags are extracted.
+    type Subject;
+
+    /// Extract cache tags from the subject.
+    ///
+    /// Takes ownership of the subject and returns it alongside the tags,
+    /// mirroring the [`Extractor`](crate::Extractor) ownership pattern.
+    async fn extract_tags(&self, subject: Self::Subject) -> (Self::Subject, Vec<CacheTag>);
+}
+
+#[async_trait]
+impl<T> TagExtractor for &T
+where
+    T: TagExtractor + ?Sized + Sync,
+    T::Subject: Send,
+{
+    type Subject = T::Subject;
+
+    async fn extract_tags(&self, subject: T::Subject) -> (T::Subject, Vec<CacheTag>) {
+        (**self).extract_tags(subject).await
+    }
+}
+
+#[async_trait]
+impl<T> TagExtractor for Box<T>
+where
+    T: TagExtractor + ?Sized + Sync,
+    T::Subject: Send,
+{
+    type Subject = T::Subject;
+
+    async fn extract_tags(&self, subject: T::Subject) -> (T::Subject, Vec<CacheTag>) {
+        self.as_ref().extract_tags(subject).await
+    }
+}
+
+#[async_trait]
+impl<T> TagExtractor for Arc<T>
+where
+    T: TagExtractor + Send + Sync + ?Sized,
+    T::Subject: Send,
+{
+    type Subject = T::Subject;
+
+    async fn extract_tags(&self, subject: T::Subject) -> (T::Subject, Vec<CacheTag>) {
+        self.as_ref().extract_tags(subject).await
+    }
+}
+
+/// Adapter that wraps an [`Extractor`] to use it as a [`TagExtractor`].
+///
+/// Converts each [`KeyPart`](crate::KeyPart) produced by the extractor into
+/// a [`CacheTag`]. This allows reusing existing extractor implementations
+/// (e.g., HTTP method, path extractors) for tag-based invalidation.
+///
+/// # Example
+///
+/// ```ignore
+/// use hitbox_core::tag::TagAdapter;
+/// use hitbox_http::extractors::MethodExtractor;
+///
+/// // Reuse the HTTP method extractor as a tag extractor
+/// let tag_extractor = TagAdapter::new(MethodExtractor::new(MethodConfig::new()));
+/// ```
+pub struct TagAdapter<E>(E);
+
+impl<E> TagAdapter<E> {
+    /// Wraps an extractor as a tag extractor.
+    pub fn new(extractor: E) -> Self {
+        TagAdapter(extractor)
+    }
+}
+
+#[async_trait]
+impl<E> TagExtractor for TagAdapter<E>
+where
+    E: Extractor + Send + Sync,
+    E::Subject: Send,
+{
+    type Subject = E::Subject;
+
+    async fn extract_tags(&self, subject: E::Subject) -> (E::Subject, Vec<CacheTag>) {
+        let key_parts = self.0.get(subject).await;
+        let (subject, cache_key) = key_parts.into_cache_key();
+        let tags = cache_key.parts().map(CacheTag::from).collect();
+        (subject, tags)
+    }
+}
+
+/// Extension trait for converting any [`Extractor`] into a [`TagExtractor`].
+///
+/// This is automatically implemented for all [`Extractor`] types.
+///
+/// # Example
+///
+/// ```ignore
+/// use hitbox_core::tag::ExtractorExt;
+///
+/// let tag_extractor = request::extractor::<Body>().path().as_tag();
+/// ```
+///
+/// [`Extractor`]: crate::Extractor
+pub trait ExtractorExt: Extractor + Sized {
+    /// Wraps this extractor as a [`TagExtractor`].
+    ///
+    /// Each [`KeyPart`](crate::KeyPart) produced by the extractor is converted
+    /// into a [`CacheTag`].
+    fn as_tag(self) -> TagAdapter<Self> {
+        TagAdapter::new(self)
+    }
+}
+
+impl<T: Extractor> ExtractorExt for T {}
+
+/// Tag extractor that runs a sequence of inner extractors and concatenates
+/// their tags.
+///
+/// Useful for composing multiple [`TagExtractor`]s — for example a static
+/// list of literal tags plus a [`TagAdapter`] over a request `Path`/`Header`
+/// extractor — into a single tag extractor that the FSM can consume.
+///
+/// Subjects are threaded through each inner extractor in order: each one
+/// receives the subject value, may produce tags, and returns the subject
+/// for the next extractor in the chain.
+pub struct ChainTagExtractor<S> {
+    inner: Vec<Box<dyn TagExtractor<Subject = S> + Send + Sync>>,
+}
+
+impl<S> ChainTagExtractor<S> {
+    /// Create a chain from an explicit vector of boxed inner tag extractors.
+    pub fn new(inner: Vec<Box<dyn TagExtractor<Subject = S> + Send + Sync>>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S> std::fmt::Debug for ChainTagExtractor<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChainTagExtractor")
+            .field("count", &self.inner.len())
+            .finish()
+    }
+}
+
+#[async_trait]
+impl<S> TagExtractor for ChainTagExtractor<S>
+where
+    S: Send,
+{
+    type Subject = S;
+
+    async fn extract_tags(&self, mut subject: S) -> (S, Vec<CacheTag>) {
+        let mut tags = Vec::new();
+        for ext in &self.inner {
+            let (returned_subject, mut new_tags) = ext.extract_tags(subject).await;
+            subject = returned_subject;
+            tags.append(&mut new_tags);
+        }
+        (subject, tags)
+    }
+}
+
+/// A no-op tag extractor that produces no tags.
+///
+/// Used as the default when no tag extraction is configured.
+///
+/// Uses `PhantomData<fn() -> S>` so that `NeutralTagExtractor<S>` is always
+/// `Send + Sync`, even when `S` is not. The phantom variance is "produces S"
+/// rather than "contains S" — appropriate for an extractor that never holds one.
+pub struct NeutralTagExtractor<S>(std::marker::PhantomData<fn() -> S>);
+
+impl<S> Default for NeutralTagExtractor<S> {
+    fn default() -> Self {
+        NeutralTagExtractor(std::marker::PhantomData)
+    }
+}
+
+#[async_trait]
+impl<S> TagExtractor for NeutralTagExtractor<S>
+where
+    S: Send,
+{
+    type Subject = S;
+
+    async fn extract_tags(&self, subject: S) -> (S, Vec<CacheTag>) {
+        (subject, Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tag extractor that emits a fixed list of tags. Test-only — production
+    /// code should use [`StaticExtractor`](crate::StaticExtractor) plus
+    /// [`ExtractorExt::as_tag`].
+    struct FixedTags(Vec<CacheTag>);
+
+    #[async_trait]
+    impl TagExtractor for FixedTags {
+        type Subject = u32;
+
+        async fn extract_tags(&self, subject: u32) -> (u32, Vec<CacheTag>) {
+            (subject, self.0.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn chain_concatenates_tags_in_order() {
+        let chain = ChainTagExtractor::<u32>::new(vec![
+            Box::new(FixedTags(vec![CacheTag::new("a"), CacheTag::new("b")])),
+            Box::new(FixedTags(vec![CacheTag::new("c")])),
+        ]);
+
+        let (subject, tags) = chain.extract_tags(7).await;
+        assert_eq!(subject, 7);
+        let strs: Vec<&str> = tags.iter().map(|t| t.as_str()).collect();
+        assert_eq!(strs, vec!["a", "b", "c"]);
+    }
+
+    #[tokio::test]
+    async fn empty_chain_produces_no_tags() {
+        let chain: ChainTagExtractor<u32> = ChainTagExtractor::new(Vec::new());
+        let (_subject, tags) = chain.extract_tags(0).await;
+        assert!(tags.is_empty());
+    }
+
+    #[tokio::test]
+    async fn chain_threads_subject_through_each_link() {
+        // Even a no-tag link must still pass the subject onward unchanged.
+        let chain = ChainTagExtractor::<u32>::new(vec![
+            Box::new(NeutralTagExtractor::<u32>::default()),
+            Box::new(FixedTags(vec![CacheTag::new("only-tag")])),
+        ]);
+
+        let (subject, tags) = chain.extract_tags(99).await;
+        assert_eq!(subject, 99);
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].as_str(), "only-tag");
+    }
+}

--- a/hitbox-core/src/value.rs
+++ b/hitbox-core/src/value.rs
@@ -3,7 +3,7 @@
 //! This module provides types for wrapping cached data with expiration
 //! and staleness timestamps:
 //!
-//! - [`CacheValue`] - Cached data with optional expire and stale timestamps
+//! - [`CacheValue`] - Cached data with creation time and expire/stale timestamps
 //! - [`CacheMeta`] - Just the metadata without the data
 //!
 //! ## Expiration vs Staleness
@@ -28,10 +28,12 @@
 //! use hitbox_core::value::CacheValue;
 //! use chrono::Utc;
 //!
+//! let now = Utc::now();
 //! let value = CacheValue::new(
 //!     "cached data",
-//!     Some(Utc::now() + chrono::Duration::hours(1)),  // expires in 1 hour
-//!     Some(Utc::now() + chrono::Duration::minutes(5)), // stale in 5 minutes
+//!     now,
+//!     Some(now + chrono::Duration::hours(1)),   // expires in 1 hour
+//!     Some(now + chrono::Duration::minutes(5)), // stale in 5 minutes
 //! );
 //!
 //! match value.cache_state() {
@@ -48,6 +50,7 @@ use std::time::Duration;
 use crate::Raw;
 use crate::policy::EntityPolicyConfig;
 use crate::response::CacheState;
+use crate::tag::CacheTags;
 
 /// A cached value with expiration metadata.
 ///
@@ -83,12 +86,16 @@ use crate::response::CacheState;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CacheValue<T> {
     data: T,
+    created: DateTime<Utc>,
     expire: Option<DateTime<Utc>>,
     stale: Option<DateTime<Utc>>,
+    tags: Option<CacheTags>,
 }
 
 impl<T> CacheValue<T> {
     /// Creates a new cache value with the given data and timestamps.
+    ///
+    /// Sets the creation time to the current time automatically.
     ///
     /// # Arguments
     ///
@@ -98,20 +105,82 @@ impl<T> CacheValue<T> {
     pub fn new(data: T, expire: Option<DateTime<Utc>>, stale: Option<DateTime<Utc>>) -> Self {
         CacheValue {
             data,
+            created: Utc::now(),
             expire,
             stale,
+            tags: None,
         }
+    }
+
+    /// Creates a cache value with an explicit creation timestamp.
+    ///
+    /// Use this when restoring a value from a backend where the creation
+    /// time is known (e.g., deserialization from Redis or envelope format).
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The data to cache
+    /// * `created` - When the entry was originally created
+    /// * `expire` - When the data expires (becomes invalid)
+    /// * `stale` - When the data becomes stale (should refresh in background)
+    pub fn with_created(
+        data: T,
+        created: DateTime<Utc>,
+        expire: Option<DateTime<Utc>>,
+        stale: Option<DateTime<Utc>>,
+    ) -> Self {
+        CacheValue {
+            data,
+            created,
+            expire,
+            stale,
+            tags: None,
+        }
+    }
+
+    /// Attaches tags to this cache value (builder-style).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let value = CacheValue::new(data, expire, stale).with_tags(tags);
+    /// ```
+    pub fn with_tags(mut self, tags: CacheTags) -> Self {
+        self.tags = Some(tags);
+        self
+    }
+
+    /// Returns a reference to the cached value's tags, if any.
+    ///
+    /// Returns `None` if no tag system was used when writing this entry,
+    /// or `Some(&tags)` if tag extractors were configured (tags may still be empty).
+    #[inline]
+    pub fn tags(&self) -> Option<&CacheTags> {
+        self.tags.as_ref()
+    }
+
+    /// Sets tags from an `Option<CacheTags>` (builder-style).
+    ///
+    /// Convenience wrapper for passing tags forward when reconstructing
+    /// `CacheValue` from metadata. Use [`with_tags`] for direct attachment.
+    ///
+    /// [`with_tags`]: Self::with_tags
+    pub fn with_optional_tags(mut self, tags: Option<CacheTags>) -> Self {
+        self.tags = tags;
+        self
     }
 
     /// Creates a new cache value using timestamps derived from an [`EntityPolicyConfig`].
     ///
-    /// Converts the config's TTL and stale TTL durations into absolute timestamps
-    /// relative to the current time.
+    /// Sets the creation time to now and converts the config's TTL and stale TTL
+    /// durations into absolute timestamps relative to the current time.
     pub fn from_config(data: T, config: &EntityPolicyConfig) -> Self {
-        Self::new(
+        let now = Utc::now();
+        Self::with_created(
             data,
-            config.ttl.map(|d| Utc::now() + d),
-            config.stale_ttl.map(|d| Utc::now() + d),
+            now,
+            config.ttl.map(|d| now + d),
+            config.stale_ttl.map(|d| now + d),
         )
     }
 
@@ -119,6 +188,12 @@ impl<T> CacheValue<T> {
     #[inline]
     pub fn data(&self) -> &T {
         &self.data
+    }
+
+    /// Returns when the entry was created.
+    #[inline]
+    pub fn created(&self) -> DateTime<Utc> {
+        self.created
     }
 
     /// Returns when the data expires (becomes invalid).
@@ -144,10 +219,13 @@ impl<T> CacheValue<T> {
     ///
     /// Useful when you need to inspect or modify the metadata independently.
     pub fn into_parts(self) -> (CacheMeta, T) {
-        (CacheMeta::new(self.expire, self.stale), self.data)
+        (
+            CacheMeta::new(self.created, self.expire, self.stale, self.tags),
+            self.data,
+        )
     }
 
-    /// Calculate TTL (time-to-live) from the expire time.
+    /// Calculate remaining TTL from the expire time.
     ///
     /// Returns `Some(Duration)` if there's a valid expire time in the future,
     /// or `None` if there's no expire time or it's already expired.
@@ -188,24 +266,33 @@ impl<T> CacheValue<T> {
 
 /// Cache expiration metadata without the data.
 ///
-/// Contains just the staleness and expiration timestamps. Useful for
-/// passing metadata around without copying the cached data.
-///
-/// # Fields
-///
-/// * `expire` - When the data expires (becomes invalid)
-/// * `stale` - When the data becomes stale (should refresh in background)
+/// Contains the creation timestamp and expiration/staleness timestamps.
+/// Useful for passing metadata around without copying the cached data.
 pub struct CacheMeta {
+    /// When the cached data was created.
+    pub created: DateTime<Utc>,
     /// When the cached data expires and becomes invalid.
     pub expire: Option<DateTime<Utc>>,
     /// When the cached data becomes stale and should be refreshed.
     pub stale: Option<DateTime<Utc>>,
+    /// Tags attached to the cached entry, if any.
+    pub tags: Option<CacheTags>,
 }
 
 impl CacheMeta {
-    /// Creates new cache metadata with the given timestamps.
-    pub fn new(expire: Option<DateTime<Utc>>, stale: Option<DateTime<Utc>>) -> CacheMeta {
-        CacheMeta { expire, stale }
+    /// Creates new cache metadata with the given timestamps and tags.
+    pub fn new(
+        created: DateTime<Utc>,
+        expire: Option<DateTime<Utc>>,
+        stale: Option<DateTime<Utc>>,
+        tags: Option<CacheTags>,
+    ) -> CacheMeta {
+        CacheMeta {
+            created,
+            expire,
+            stale,
+            tags,
+        }
     }
 }
 

--- a/hitbox-core/tests/response.rs
+++ b/hitbox-core/tests/response.rs
@@ -1,7 +1,9 @@
 use async_trait::async_trait;
 use chrono::Utc;
+use hitbox_core::tag::{CacheTag, NeutralTagExtractor, TagExtractor};
 use hitbox_core::{
     CachePolicy, CacheValue, CacheableResponse, EntityPolicyConfig, Predicate, PredicateResult,
+    ResponseCachePolicy,
 };
 
 #[derive(Clone, Debug)]
@@ -27,22 +29,32 @@ impl CacheableResponse for TestResponse {
     type IntoCachedFuture = std::future::Ready<CachePolicy<Self::Cached, Self>>;
     type FromCachedFuture = std::future::Ready<Self>;
 
-    async fn cache_policy<P>(
+    async fn cache_policy<P, TE>(
         self,
         predicates: P,
+        tag_extractor: TE,
         _config: &EntityPolicyConfig,
-    ) -> hitbox_core::ResponseCachePolicy<Self>
+    ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where
-        P: hitbox_core::Predicate<Subject = Self::Subject> + Send + Sync,
+        P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
     {
         match predicates.check(self).await {
-            PredicateResult::Cacheable(cacheable) => match cacheable.into_cached().await {
-                CachePolicy::Cacheable(res) => {
-                    CachePolicy::Cacheable(CacheValue::new(res, Some(Utc::now()), Some(Utc::now())))
+            PredicateResult::Cacheable(cacheable) => {
+                let (cacheable, tags) = tag_extractor.extract_tags(cacheable).await;
+                match cacheable.into_cached().await {
+                    CachePolicy::Cacheable(res) => (
+                        CachePolicy::Cacheable(CacheValue::new(
+                            res,
+                            Some(Utc::now()),
+                            Some(Utc::now()),
+                        )),
+                        tags,
+                    ),
+                    CachePolicy::NonCacheable(res) => (CachePolicy::NonCacheable(res), tags),
                 }
-                CachePolicy::NonCacheable(res) => CachePolicy::NonCacheable(res),
-            },
-            PredicateResult::NonCacheable(res) => CachePolicy::NonCacheable(res),
+            }
+            PredicateResult::NonCacheable(res) => (CachePolicy::NonCacheable(res), Vec::new()),
         }
     }
 
@@ -77,13 +89,21 @@ impl Predicate for NeuralPredicate {
 async fn test_cacheable_result() {
     let response: Result<TestResponse, ()> = Ok(TestResponse::new());
     let policy = response
-        .cache_policy(NeuralPredicate::new(), &EntityPolicyConfig::default())
+        .cache_policy(
+            NeuralPredicate::new(),
+            NeutralTagExtractor::default(),
+            &EntityPolicyConfig::default(),
+        )
         .await;
     dbg!(&policy);
 
     let response: Result<TestResponse, ()> = Err(());
     let policy = response
-        .cache_policy(NeuralPredicate::new(), &EntityPolicyConfig::default())
+        .cache_policy(
+            NeuralPredicate::new(),
+            NeutralTagExtractor::default(),
+            &EntityPolicyConfig::default(),
+        )
         .await;
     dbg!(&policy);
 }

--- a/hitbox-core/tests/response.rs
+++ b/hitbox-core/tests/response.rs
@@ -32,7 +32,7 @@ impl CacheableResponse for TestResponse {
     async fn cache_policy<P, TE>(
         self,
         predicates: P,
-        tag_extractor: TE,
+        tag_extractor: Option<TE>,
         _config: &EntityPolicyConfig,
     ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where
@@ -41,7 +41,10 @@ impl CacheableResponse for TestResponse {
     {
         match predicates.check(self).await {
             PredicateResult::Cacheable(cacheable) => {
-                let (cacheable, tags) = tag_extractor.extract_tags(cacheable).await;
+                let (cacheable, tags) = match tag_extractor {
+                    Some(te) => te.extract_tags(cacheable).await,
+                    None => (cacheable, Vec::new()),
+                };
                 match cacheable.into_cached().await {
                     CachePolicy::Cacheable(res) => (
                         CachePolicy::Cacheable(CacheValue::new(
@@ -91,7 +94,7 @@ async fn test_cacheable_result() {
     let policy = response
         .cache_policy(
             NeuralPredicate::new(),
-            NeutralTagExtractor::default(),
+            Some(NeutralTagExtractor::default()),
             &EntityPolicyConfig::default(),
         )
         .await;
@@ -101,7 +104,7 @@ async fn test_cacheable_result() {
     let policy = response
         .cache_policy(
             NeuralPredicate::new(),
-            NeutralTagExtractor::default(),
+            Some(NeutralTagExtractor::default()),
             &EntityPolicyConfig::default(),
         )
         .await;

--- a/hitbox-derive/src/cacheable_request/trait_impl.rs
+++ b/hitbox-derive/src/cacheable_request/trait_impl.rs
@@ -44,7 +44,7 @@ impl<'a> ToTokens for CacheableRequestImpl<'a> {
                     self,
                     predicates: __P,
                     extractors: __E,
-                    tag_extractor: __TE,
+                    tag_extractor: ::std::option::Option<__TE>,
                 ) -> Self::CachePolicyFuture<'__a, __P, __E, __TE>
                 where
                     Self: '__a,
@@ -56,7 +56,14 @@ impl<'a> ToTokens for CacheableRequestImpl<'a> {
                         match predicates.check(self).await {
                             hitbox::predicate::PredicateResult::Cacheable(subject) => {
                                 let (subject, key) = extractors.get(subject).await.into_cache_key();
-                                let (subject, tags) = tag_extractor.extract_tags(subject).await;
+                                let (subject, tags) = match tag_extractor {
+                                    ::std::option::Option::Some(__te) => {
+                                        __te.extract_tags(subject).await
+                                    }
+                                    ::std::option::Option::None => {
+                                        (subject, ::std::vec::Vec::new())
+                                    }
+                                };
                                 (
                                     hitbox::CachePolicy::Cacheable(
                                         hitbox::CacheablePolicyData::new(key, subject)

--- a/hitbox-derive/src/cacheable_request/trait_impl.rs
+++ b/hitbox-derive/src/cacheable_request/trait_impl.rs
@@ -24,36 +24,48 @@ impl<'a> ToTokens for CacheableRequestImpl<'a> {
 
         let expanded = quote! {
             impl #impl_generics hitbox::CacheableRequest for #name #ty_generics #where_clause {
-                type CachePolicyFuture<'__a, __P, __E> = ::std::pin::Pin<
+                type CachePolicyFuture<'__a, __P, __E, __TE> = ::std::pin::Pin<
                     ::std::boxed::Box<
-                        dyn ::std::future::Future<Output = hitbox::RequestCachePolicy<Self>> + Send + '__a
+                        dyn ::std::future::Future<
+                            Output = (
+                                hitbox::RequestCachePolicy<Self>,
+                                ::std::vec::Vec<hitbox_core::tag::CacheTag>,
+                            )
+                        > + Send + '__a
                     >
                 >
                 where
                     Self: '__a,
                     __P: hitbox::predicate::Predicate<Subject = Self> + Send + Sync + '__a,
-                    __E: hitbox::Extractor<Subject = Self> + Send + Sync + '__a;
+                    __E: hitbox::Extractor<Subject = Self> + Send + Sync + '__a,
+                    __TE: hitbox_core::tag::TagExtractor<Subject = Self> + Send + Sync + '__a;
 
-                fn cache_policy<'__a, __P, __E>(
+                fn cache_policy<'__a, __P, __E, __TE>(
                     self,
                     predicates: __P,
                     extractors: __E,
-                ) -> Self::CachePolicyFuture<'__a, __P, __E>
+                    tag_extractor: __TE,
+                ) -> Self::CachePolicyFuture<'__a, __P, __E, __TE>
                 where
                     Self: '__a,
                     __P: hitbox::predicate::Predicate<Subject = Self> + Send + Sync + '__a,
                     __E: hitbox::Extractor<Subject = Self> + Send + Sync + '__a,
+                    __TE: hitbox_core::tag::TagExtractor<Subject = Self> + Send + Sync + '__a,
                 {
                     ::std::boxed::Box::pin(async move {
                         match predicates.check(self).await {
                             hitbox::predicate::PredicateResult::Cacheable(subject) => {
                                 let (subject, key) = extractors.get(subject).await.into_cache_key();
-                                hitbox::CachePolicy::Cacheable(
-                                    hitbox::CacheablePolicyData::new(key, subject)
+                                let (subject, tags) = tag_extractor.extract_tags(subject).await;
+                                (
+                                    hitbox::CachePolicy::Cacheable(
+                                        hitbox::CacheablePolicyData::new(key, subject)
+                                    ),
+                                    tags,
                                 )
                             }
                             hitbox::predicate::PredicateResult::NonCacheable(subject) => {
-                                hitbox::CachePolicy::NonCacheable(subject)
+                                (hitbox::CachePolicy::NonCacheable(subject), ::std::vec::Vec::new())
                             }
                         }
                     })

--- a/hitbox-derive/src/cacheable_response/trait_impl.rs
+++ b/hitbox-derive/src/cacheable_response/trait_impl.rs
@@ -44,7 +44,7 @@ impl<'a> CacheableResponseImpl<'a> {
                 async fn cache_policy<__P, __TE>(
                     self,
                     predicates: __P,
-                    tag_extractor: __TE,
+                    tag_extractor: ::std::option::Option<__TE>,
                     config: &hitbox::EntityPolicyConfig,
                 ) -> (
                     hitbox::ResponseCachePolicy<Self>,
@@ -56,7 +56,14 @@ impl<'a> CacheableResponseImpl<'a> {
                 {
                     match predicates.check(self).await {
                         hitbox::predicate::PredicateResult::Cacheable(data) => {
-                            let (data, tags) = tag_extractor.extract_tags(data).await;
+                            let (data, tags) = match tag_extractor {
+                                ::std::option::Option::Some(__te) => {
+                                    __te.extract_tags(data).await
+                                }
+                                ::std::option::Option::None => {
+                                    (data, ::std::vec::Vec::new())
+                                }
+                            };
                             let cached = data.clone();
                             (
                                 hitbox::CachePolicy::Cacheable(
@@ -108,7 +115,7 @@ impl<'a> CacheableResponseImpl<'a> {
                 async fn cache_policy<__P, __TE>(
                     self,
                     predicates: __P,
-                    tag_extractor: __TE,
+                    tag_extractor: ::std::option::Option<__TE>,
                     config: &hitbox::EntityPolicyConfig,
                 ) -> (
                     hitbox::ResponseCachePolicy<Self>,
@@ -120,7 +127,14 @@ impl<'a> CacheableResponseImpl<'a> {
                 {
                     match predicates.check(self).await {
                         hitbox::predicate::PredicateResult::Cacheable(data) => {
-                            let (data, tags) = tag_extractor.extract_tags(data).await;
+                            let (data, tags) = match tag_extractor {
+                                ::std::option::Option::Some(__te) => {
+                                    __te.extract_tags(data).await
+                                }
+                                ::std::option::Option::None => {
+                                    (data, ::std::vec::Vec::new())
+                                }
+                            };
                             let cached = #cached_name {
                                 #(#field_idents: data.#field_idents,)*
                             };

--- a/hitbox-derive/src/cacheable_response/trait_impl.rs
+++ b/hitbox-derive/src/cacheable_response/trait_impl.rs
@@ -41,23 +41,32 @@ impl<'a> CacheableResponseImpl<'a> {
                 type IntoCachedFuture = std::future::Ready<hitbox::CachePolicy<Self, Self>>;
                 type FromCachedFuture = std::future::Ready<Self>;
 
-                async fn cache_policy<__P>(
+                async fn cache_policy<__P, __TE>(
                     self,
                     predicates: __P,
+                    tag_extractor: __TE,
                     config: &hitbox::EntityPolicyConfig,
-                ) -> hitbox::ResponseCachePolicy<Self>
+                ) -> (
+                    hitbox::ResponseCachePolicy<Self>,
+                    ::std::vec::Vec<hitbox::tag::CacheTag>,
+                )
                 where
                     __P: hitbox::predicate::Predicate<Subject = Self::Subject> + Send + Sync,
+                    __TE: hitbox::tag::TagExtractor<Subject = Self::Subject> + Send + Sync,
                 {
                     match predicates.check(self).await {
                         hitbox::predicate::PredicateResult::Cacheable(data) => {
+                            let (data, tags) = tag_extractor.extract_tags(data).await;
                             let cached = data.clone();
-                            hitbox::CachePolicy::Cacheable(
-                                hitbox::CacheValue::from_config(cached, config),
+                            (
+                                hitbox::CachePolicy::Cacheable(
+                                    hitbox::CacheValue::from_config(cached, config),
+                                ),
+                                tags,
                             )
                         }
                         hitbox::predicate::PredicateResult::NonCacheable(data) => {
-                            hitbox::CachePolicy::NonCacheable(data)
+                            (hitbox::CachePolicy::NonCacheable(data), ::std::vec::Vec::new())
                         }
                     }
                 }
@@ -96,25 +105,34 @@ impl<'a> CacheableResponseImpl<'a> {
                 type IntoCachedFuture = std::future::Ready<hitbox::CachePolicy<Self::Cached, Self>>;
                 type FromCachedFuture = std::future::Ready<Self>;
 
-                async fn cache_policy<__P>(
+                async fn cache_policy<__P, __TE>(
                     self,
                     predicates: __P,
+                    tag_extractor: __TE,
                     config: &hitbox::EntityPolicyConfig,
-                ) -> hitbox::ResponseCachePolicy<Self>
+                ) -> (
+                    hitbox::ResponseCachePolicy<Self>,
+                    ::std::vec::Vec<hitbox::tag::CacheTag>,
+                )
                 where
                     __P: hitbox::predicate::Predicate<Subject = Self::Subject> + Send + Sync,
+                    __TE: hitbox::tag::TagExtractor<Subject = Self::Subject> + Send + Sync,
                 {
                     match predicates.check(self).await {
                         hitbox::predicate::PredicateResult::Cacheable(data) => {
+                            let (data, tags) = tag_extractor.extract_tags(data).await;
                             let cached = #cached_name {
                                 #(#field_idents: data.#field_idents,)*
                             };
-                            hitbox::CachePolicy::Cacheable(
-                                hitbox::CacheValue::from_config(cached, config),
+                            (
+                                hitbox::CachePolicy::Cacheable(
+                                    hitbox::CacheValue::from_config(cached, config),
+                                ),
+                                tags,
                             )
                         }
                         hitbox::predicate::PredicateResult::NonCacheable(data) => {
-                            hitbox::CachePolicy::NonCacheable(data)
+                            (hitbox::CachePolicy::NonCacheable(data), ::std::vec::Vec::new())
                         }
                     }
                 }

--- a/hitbox-feoxdb/src/backend.rs
+++ b/hitbox-feoxdb/src/backend.rs
@@ -16,6 +16,7 @@ use hitbox_backend::{
     Backend, BackendError, BackendResult, CacheKeyFormat, Compressor, DeleteStatus,
     PassthroughCompressor,
 };
+use hitbox_core::tag::CacheTags;
 use hitbox_core::{BackendLabel, CacheKey, CacheValue, Raw};
 use serde::{Deserialize, Serialize};
 
@@ -25,23 +26,40 @@ use crate::FeOxDbError;
 struct SerializableCacheValue {
     #[serde(with = "serde_bytes")]
     data: Vec<u8>,
+    /// Creation timestamp. `None` for backward compat with pre-0.3 entries.
+    #[serde(default)]
+    created: Option<DateTime<Utc>>,
     stale: Option<DateTime<Utc>>,
     expire: Option<DateTime<Utc>>,
+    /// Tags attached to the entry. `None` for backward compat with pre-tag entries.
+    #[serde(default)]
+    tags: Option<CacheTags>,
 }
 
 impl From<CacheValue<Raw>> for SerializableCacheValue {
     fn from(value: CacheValue<Raw>) -> Self {
         Self {
             data: value.data().to_vec(),
+            created: Some(value.created()),
             stale: value.stale(),
             expire: value.expire(),
+            tags: value.tags().cloned(),
         }
     }
 }
 
 impl From<SerializableCacheValue> for CacheValue<Raw> {
     fn from(value: SerializableCacheValue) -> Self {
-        CacheValue::new(Bytes::from(value.data), value.expire, value.stale)
+        let cv = CacheValue::with_created(
+            Bytes::from(value.data),
+            value.created.unwrap_or(DateTime::UNIX_EPOCH),
+            value.expire,
+            value.stale,
+        );
+        match value.tags {
+            Some(tags) => cv.with_tags(tags),
+            None => cv,
+        }
     }
 }
 

--- a/hitbox-fn/src/args.rs
+++ b/hitbox-fn/src/args.rs
@@ -4,10 +4,10 @@ use std::future::Future;
 use std::pin::Pin;
 
 use hitbox::{
-    CachePolicy, CacheableRequest, Extractor, KeyPart, Predicate, RequestCachePolicy,
+    CachePolicy, CacheablePolicyData, CacheableRequest, Extractor, KeyPart, Predicate,
+    RequestCachePolicy,
     predicate::PredicateResult,
     tag::{CacheTag, TagExtractor},
-    CacheablePolicyData,
 };
 
 use crate::KeyExtract;
@@ -124,7 +124,7 @@ macro_rules! impl_cacheable_request_for_args {
                 self,
                 predicates: P,
                 extractors: E,
-                tag_extractor: TE,
+                tag_extractor: Option<TE>,
             ) -> Self::CachePolicyFuture<'a, P, E, TE>
             where
                 Self: 'a,
@@ -136,7 +136,10 @@ macro_rules! impl_cacheable_request_for_args {
                     match predicates.check(self).await {
                         PredicateResult::Cacheable(subject) => {
                             let (subject, key) = extractors.get(subject).await.into_cache_key();
-                            let (subject, tags) = tag_extractor.extract_tags(subject).await;
+                            let (subject, tags) = match tag_extractor {
+                                Some(te) => te.extract_tags(subject).await,
+                                None => (subject, Vec::new()),
+                            };
                             (
                                 CachePolicy::Cacheable(CacheablePolicyData::new(key, subject)),
                                 tags,
@@ -162,7 +165,7 @@ macro_rules! impl_cacheable_request_for_args {
                 self,
                 predicates: P,
                 extractors: E,
-                tag_extractor: TE,
+                tag_extractor: Option<TE>,
             ) -> Self::CachePolicyFuture<'a, P, E, TE>
             where
                 Self: 'a,
@@ -174,7 +177,10 @@ macro_rules! impl_cacheable_request_for_args {
                     match predicates.check(self).await {
                         PredicateResult::Cacheable(subject) => {
                             let (subject, key) = extractors.get(subject).await.into_cache_key();
-                            let (subject, tags) = tag_extractor.extract_tags(subject).await;
+                            let (subject, tags) = match tag_extractor {
+                                Some(te) => te.extract_tags(subject).await,
+                                None => (subject, Vec::new()),
+                            };
                             (
                                 CachePolicy::Cacheable(CacheablePolicyData::new(key, subject)),
                                 tags,

--- a/hitbox-fn/src/args.rs
+++ b/hitbox-fn/src/args.rs
@@ -6,6 +6,8 @@ use std::pin::Pin;
 use hitbox::{
     CachePolicy, CacheableRequest, Extractor, KeyPart, Predicate, RequestCachePolicy,
     predicate::PredicateResult,
+    tag::{CacheTag, TagExtractor},
+    CacheablePolicyData,
 };
 
 use crate::KeyExtract;
@@ -110,30 +112,37 @@ impl<T> Args<T> {
 macro_rules! impl_cacheable_request_for_args {
     () => {
         impl CacheableRequest for Args<()> {
-            type CachePolicyFuture<'a, P, E>
-                = Pin<Box<dyn Future<Output = RequestCachePolicy<Self>> + Send + 'a>>
-            where
-                Self: 'a,
-                P: Predicate<Subject = Self> + Send + Sync + 'a,
-                E: Extractor<Subject = Self> + Send + Sync + 'a;
-
-            fn cache_policy<'a, P, E>(
-                self,
-                predicates: P,
-                extractors: E,
-            ) -> Self::CachePolicyFuture<'a, P, E>
+            type CachePolicyFuture<'a, P, E, TE>
+                = Pin<Box<dyn Future<Output = (RequestCachePolicy<Self>, Vec<CacheTag>)> + Send + 'a>>
             where
                 Self: 'a,
                 P: Predicate<Subject = Self> + Send + Sync + 'a,
                 E: Extractor<Subject = Self> + Send + Sync + 'a,
+                TE: TagExtractor<Subject = Self> + Send + Sync + 'a;
+
+            fn cache_policy<'a, P, E, TE>(
+                self,
+                predicates: P,
+                extractors: E,
+                tag_extractor: TE,
+            ) -> Self::CachePolicyFuture<'a, P, E, TE>
+            where
+                Self: 'a,
+                P: Predicate<Subject = Self> + Send + Sync + 'a,
+                E: Extractor<Subject = Self> + Send + Sync + 'a,
+                TE: TagExtractor<Subject = Self> + Send + Sync + 'a,
             {
                 Box::pin(async move {
                     match predicates.check(self).await {
                         PredicateResult::Cacheable(subject) => {
                             let (subject, key) = extractors.get(subject).await.into_cache_key();
-                            CachePolicy::Cacheable(hitbox::CacheablePolicyData::new(key, subject))
+                            let (subject, tags) = tag_extractor.extract_tags(subject).await;
+                            (
+                                CachePolicy::Cacheable(CacheablePolicyData::new(key, subject)),
+                                tags,
+                            )
                         }
-                        PredicateResult::NonCacheable(subject) => CachePolicy::NonCacheable(subject),
+                        PredicateResult::NonCacheable(subject) => (CachePolicy::NonCacheable(subject), Vec::new()),
                     }
                 })
             }
@@ -141,30 +150,37 @@ macro_rules! impl_cacheable_request_for_args {
     };
     ($($T:ident),+) => {
         impl<$($T: Send + Sync),+> CacheableRequest for Args<($($T,)+)> {
-            type CachePolicyFuture<'a, P, E>
-                = Pin<Box<dyn Future<Output = RequestCachePolicy<Self>> + Send + 'a>>
-            where
-                Self: 'a,
-                P: Predicate<Subject = Self> + Send + Sync + 'a,
-                E: Extractor<Subject = Self> + Send + Sync + 'a;
-
-            fn cache_policy<'a, P, E>(
-                self,
-                predicates: P,
-                extractors: E,
-            ) -> Self::CachePolicyFuture<'a, P, E>
+            type CachePolicyFuture<'a, P, E, TE>
+                = Pin<Box<dyn Future<Output = (RequestCachePolicy<Self>, Vec<CacheTag>)> + Send + 'a>>
             where
                 Self: 'a,
                 P: Predicate<Subject = Self> + Send + Sync + 'a,
                 E: Extractor<Subject = Self> + Send + Sync + 'a,
+                TE: TagExtractor<Subject = Self> + Send + Sync + 'a;
+
+            fn cache_policy<'a, P, E, TE>(
+                self,
+                predicates: P,
+                extractors: E,
+                tag_extractor: TE,
+            ) -> Self::CachePolicyFuture<'a, P, E, TE>
+            where
+                Self: 'a,
+                P: Predicate<Subject = Self> + Send + Sync + 'a,
+                E: Extractor<Subject = Self> + Send + Sync + 'a,
+                TE: TagExtractor<Subject = Self> + Send + Sync + 'a,
             {
                 Box::pin(async move {
                     match predicates.check(self).await {
                         PredicateResult::Cacheable(subject) => {
                             let (subject, key) = extractors.get(subject).await.into_cache_key();
-                            CachePolicy::Cacheable(hitbox::CacheablePolicyData::new(key, subject))
+                            let (subject, tags) = tag_extractor.extract_tags(subject).await;
+                            (
+                                CachePolicy::Cacheable(CacheablePolicyData::new(key, subject)),
+                                tags,
+                            )
                         }
-                        PredicateResult::NonCacheable(subject) => CachePolicy::NonCacheable(subject),
+                        PredicateResult::NonCacheable(subject) => (CachePolicy::NonCacheable(subject), Vec::new()),
                     }
                 })
             }

--- a/hitbox-http/src/request/mod.rs
+++ b/hitbox-http/src/request/mod.rs
@@ -152,13 +152,10 @@ where
 {
     type CachePolicyFuture<'a, P, E, TE>
         = std::pin::Pin<
-            Box<
-                dyn std::future::Future<
-                        Output = (RequestCachePolicy<Self>, Vec<CacheTag>),
-                    > + Send
-                    + 'a,
-            >,
-        >
+        Box<
+            dyn std::future::Future<Output = (RequestCachePolicy<Self>, Vec<CacheTag>)> + Send + 'a,
+        >,
+    >
     where
         Self: 'a,
         P: Predicate<Subject = Self> + Send + Sync + 'a,
@@ -169,7 +166,7 @@ where
         self,
         predicates: P,
         extractors: E,
-        tag_extractor: TE,
+        tag_extractor: Option<TE>,
     ) -> Self::CachePolicyFuture<'a, P, E, TE>
     where
         Self: 'a,
@@ -182,7 +179,10 @@ where
 
             match predicates.check(request).await {
                 PredicateResult::Cacheable(request) => {
-                    let (request, tags) = tag_extractor.extract_tags(request).await;
+                    let (request, tags) = match tag_extractor {
+                        Some(te) => te.extract_tags(request).await,
+                        None => (request, Vec::new()),
+                    };
                     (
                         CachePolicy::Cacheable(CacheablePolicyData { key, request }),
                         tags,

--- a/hitbox-http/src/request/mod.rs
+++ b/hitbox-http/src/request/mod.rs
@@ -4,6 +4,7 @@ pub use crate::predicates::request::predicate;
 use hitbox::{
     CacheablePolicyData, RequestCachePolicy,
     predicate::{Predicate, PredicateResult},
+    tag::{CacheTag, TagExtractor},
     {CachePolicy, CacheableRequest, Extractor},
 };
 use http::{Request, request::Parts};
@@ -149,31 +150,47 @@ where
     ReqBody: HttpBody + Send + 'static,
     ReqBody::Error: Send,
 {
-    type CachePolicyFuture<'a, P, E>
-        = std::pin::Pin<Box<dyn std::future::Future<Output = RequestCachePolicy<Self>> + Send + 'a>>
-    where
-        Self: 'a,
-        P: Predicate<Subject = Self> + Send + Sync + 'a,
-        E: Extractor<Subject = Self> + Send + Sync + 'a;
-
-    fn cache_policy<'a, P, E>(
-        self,
-        predicates: P,
-        extractors: E,
-    ) -> Self::CachePolicyFuture<'a, P, E>
+    type CachePolicyFuture<'a, P, E, TE>
+        = std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = (RequestCachePolicy<Self>, Vec<CacheTag>),
+                    > + Send
+                    + 'a,
+            >,
+        >
     where
         Self: 'a,
         P: Predicate<Subject = Self> + Send + Sync + 'a,
         E: Extractor<Subject = Self> + Send + Sync + 'a,
+        TE: TagExtractor<Subject = Self> + Send + Sync + 'a;
+
+    fn cache_policy<'a, P, E, TE>(
+        self,
+        predicates: P,
+        extractors: E,
+        tag_extractor: TE,
+    ) -> Self::CachePolicyFuture<'a, P, E, TE>
+    where
+        Self: 'a,
+        P: Predicate<Subject = Self> + Send + Sync + 'a,
+        E: Extractor<Subject = Self> + Send + Sync + 'a,
+        TE: TagExtractor<Subject = Self> + Send + Sync + 'a,
     {
         Box::pin(async move {
             let (request, key) = extractors.get(self).await.into_cache_key();
 
             match predicates.check(request).await {
                 PredicateResult::Cacheable(request) => {
-                    CachePolicy::Cacheable(CacheablePolicyData { key, request })
+                    let (request, tags) = tag_extractor.extract_tags(request).await;
+                    (
+                        CachePolicy::Cacheable(CacheablePolicyData { key, request }),
+                        tags,
+                    )
                 }
-                PredicateResult::NonCacheable(request) => CachePolicy::NonCacheable(request),
+                PredicateResult::NonCacheable(request) => {
+                    (CachePolicy::NonCacheable(request), Vec::new())
+                }
             }
         })
     }

--- a/hitbox-http/src/response/mod.rs
+++ b/hitbox-http/src/response/mod.rs
@@ -417,7 +417,7 @@ where
     async fn cache_policy<P, TE>(
         self,
         predicates: P,
-        tag_extractor: TE,
+        tag_extractor: Option<TE>,
         config: &EntityPolicyConfig,
     ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where
@@ -426,7 +426,10 @@ where
     {
         match predicates.check(self).await {
             PredicateResult::Cacheable(cacheable) => {
-                let (cacheable, tags) = tag_extractor.extract_tags(cacheable).await;
+                let (cacheable, tags) = match tag_extractor {
+                    Some(te) => te.extract_tags(cacheable).await,
+                    None => (cacheable, Vec::new()),
+                };
                 match cacheable.into_cached().await {
                     CachePolicy::Cacheable(res) => (
                         CachePolicy::Cacheable(CacheValue::from_config(res, config)),

--- a/hitbox-http/src/response/mod.rs
+++ b/hitbox-http/src/response/mod.rs
@@ -4,11 +4,12 @@ use std::fmt::Debug;
 use std::future::Ready;
 
 use bytes::Bytes;
-use chrono::Utc;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use hitbox::{
-    CachePolicy, CacheValue, CacheableResponse, EntityPolicyConfig, predicate::PredicateResult,
+    CachePolicy, CacheValue, CacheableResponse, EntityPolicyConfig, Predicate, ResponseCachePolicy,
+    predicate::PredicateResult,
+    tag::{CacheTag, TagExtractor},
 };
 use http::{HeaderMap, Response, response::Parts};
 use hyper::body::Body as HttpBody;
@@ -413,24 +414,28 @@ where
     type IntoCachedFuture = BoxFuture<'static, CachePolicy<Self::Cached, Self>>;
     type FromCachedFuture = Ready<Self>;
 
-    async fn cache_policy<P>(
+    async fn cache_policy<P, TE>(
         self,
         predicates: P,
+        tag_extractor: TE,
         config: &EntityPolicyConfig,
-    ) -> hitbox::ResponseCachePolicy<Self>
+    ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where
-        P: hitbox::Predicate<Subject = Self::Subject> + Send + Sync,
+        P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
     {
         match predicates.check(self).await {
-            PredicateResult::Cacheable(cacheable) => match cacheable.into_cached().await {
-                CachePolicy::Cacheable(res) => CachePolicy::Cacheable(CacheValue::new(
-                    res,
-                    config.ttl.map(|duration| Utc::now() + duration),
-                    config.stale_ttl.map(|duration| Utc::now() + duration),
-                )),
-                CachePolicy::NonCacheable(res) => CachePolicy::NonCacheable(res),
-            },
-            PredicateResult::NonCacheable(res) => CachePolicy::NonCacheable(res),
+            PredicateResult::Cacheable(cacheable) => {
+                let (cacheable, tags) = tag_extractor.extract_tags(cacheable).await;
+                match cacheable.into_cached().await {
+                    CachePolicy::Cacheable(res) => (
+                        CachePolicy::Cacheable(CacheValue::from_config(res, config)),
+                        tags,
+                    ),
+                    CachePolicy::NonCacheable(res) => (CachePolicy::NonCacheable(res), tags),
+                }
+            }
+            PredicateResult::NonCacheable(res) => (CachePolicy::NonCacheable(res), Vec::new()),
         }
     }
 

--- a/hitbox-moka/Cargo.toml
+++ b/hitbox-moka/Cargo.toml
@@ -22,6 +22,7 @@ hitbox-backend = { path = "../hitbox-backend", version = "0.2" }
 hitbox = { path = "../hitbox", version = "0.2" }
 hitbox-core = { path = "../hitbox-core", version = "0.2" }
 async-trait = { workspace = true }
+futures = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/hitbox-moka/src/backend.rs
+++ b/hitbox-moka/src/backend.rs
@@ -235,14 +235,10 @@ where
         &self,
         tags: &[CacheTag],
     ) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
-        let lookups = tags.iter().map(|tag| async move {
-            self.tags.get(tag).await.map(|ts| (tag.clone(), ts))
-        });
-        let result = join_all(lookups)
-            .await
-            .into_iter()
-            .flatten()
-            .collect();
+        let lookups = tags
+            .iter()
+            .map(|tag| async move { self.tags.get(tag).await.map(|ts| (tag.clone(), ts)) });
+        let result = join_all(lookups).await.into_iter().flatten().collect();
         Ok(result)
     }
 }

--- a/hitbox-moka/src/backend.rs
+++ b/hitbox-moka/src/backend.rs
@@ -1,12 +1,17 @@
 //! Moka backend implementation.
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use futures::future::join_all;
 use hitbox::{BackendLabel, CacheKey, CacheValue, Raw};
 use hitbox_backend::Backend;
 use hitbox_backend::format::{Format, JsonFormat};
 use hitbox_backend::{
     BackendResult, CacheKeyFormat, Compressor, DeleteStatus, PassthroughCompressor,
 };
+use hitbox_core::CacheTag;
 use moka::future::Cache;
 
 /// In-memory cache backend powered by Moka.
@@ -50,6 +55,17 @@ use moka::future::Cache;
 /// - **Write operations**: Fine-grained locking, O(1) average
 /// - **Memory**: Bounded by `max_capacity` entries
 ///
+/// # Tag Invalidation Storage
+///
+/// Tag invalidation timestamps are kept in a **separate, unbounded** Moka
+/// cache rather than sharing the data cache's eviction budget. This
+/// matters for correctness: if a tag's invalidation record were evicted
+/// under data write pressure, a subsequent read would see "no record" and
+/// incorrectly treat the entry as never invalidated, serving stale data.
+/// The dedicated tag store has no size cap and no expiry — records are
+/// tiny (`CacheTag` → `DateTime<Utc>`) and persist for the process
+/// lifetime.
+///
 /// # Caveats
 ///
 /// - Data is **not persisted** — cache is lost on process restart
@@ -68,6 +84,12 @@ where
     C: Compressor,
 {
     pub(crate) cache: Cache<CacheKey, CacheValue<Raw>>,
+    /// Dedicated, unbounded store for tag invalidation timestamps.
+    ///
+    /// Kept separate from `cache` so data write pressure can never evict a
+    /// tag invalidation record (which would silently break invalidation —
+    /// see the type-level "Tag Invalidation Storage" docs).
+    pub(crate) tags: Cache<CacheTag, DateTime<Utc>>,
     pub(crate) key_format: CacheKeyFormat,
     pub(crate) serializer: S,
     pub(crate) compressor: C,
@@ -193,6 +215,35 @@ where
 
     fn compressor(&self) -> &dyn Compressor {
         &self.compressor
+    }
+
+    /// Records a tag invalidation in the dedicated, unbounded tag store.
+    ///
+    /// Overrides the default `Backend` impl (which would route through
+    /// `write` and share the data cache's eviction budget).
+    async fn invalidate(&self, tag: &CacheTag) -> BackendResult<()> {
+        self.tags.insert(tag.clone(), Utc::now()).await;
+        Ok(())
+    }
+
+    /// Looks up invalidation timestamps from the dedicated tag store.
+    ///
+    /// Lookups run concurrently. Tags with no record are absent from the
+    /// returned map (never invalidated). Overrides the default `Backend`
+    /// impl.
+    async fn invalidated(
+        &self,
+        tags: &[CacheTag],
+    ) -> BackendResult<HashMap<CacheTag, DateTime<Utc>>> {
+        let lookups = tags.iter().map(|tag| async move {
+            self.tags.get(tag).await.map(|ts| (tag.clone(), ts))
+        });
+        let result = join_all(lookups)
+            .await
+            .into_iter()
+            .flatten()
+            .collect();
+        Ok(result)
     }
 }
 

--- a/hitbox-moka/src/builder.rs
+++ b/hitbox-moka/src/builder.rs
@@ -9,9 +9,9 @@ use moka::policy::EvictionPolicy;
 
 use crate::backend::MokaBackend;
 use hitbox::{BackendLabel, CacheKey, CacheValue, Raw};
-use hitbox_core::CacheTag;
 use hitbox_backend::format::{Format, JsonFormat};
 use hitbox_backend::{CacheKeyFormat, Compressor, PassthroughCompressor};
+use hitbox_core::CacheTag;
 
 /// Custom expiration policy that calculates TTL from [`CacheValue::expire`] timestamps.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/hitbox-moka/src/builder.rs
+++ b/hitbox-moka/src/builder.rs
@@ -2,13 +2,14 @@
 
 use std::time::{Duration, Instant};
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use moka::Expiry;
 use moka::future::{Cache, CacheBuilder};
 use moka::policy::EvictionPolicy;
 
 use crate::backend::MokaBackend;
 use hitbox::{BackendLabel, CacheKey, CacheValue, Raw};
+use hitbox_core::CacheTag;
 use hitbox_backend::format::{Format, JsonFormat};
 use hitbox_backend::{CacheKeyFormat, Compressor, PassthroughCompressor};
 
@@ -54,6 +55,16 @@ impl Expiration {
             }
         })
     }
+}
+
+/// Builds the dedicated, unbounded tag invalidation store.
+///
+/// Tag records (`CacheTag` → `DateTime<Utc>`) are kept apart from the data
+/// cache so data write pressure can never evict an invalidation record.
+/// No `max_capacity` is set, so the store never evicts; there is also no
+/// expiry — records persist for the process lifetime.
+fn build_tag_cache() -> Cache<CacheTag, DateTime<Utc>> {
+    Cache::builder().build()
 }
 
 /// Marker type: capacity has not been configured yet.
@@ -397,6 +408,7 @@ where
 
         MokaBackend {
             cache,
+            tags: build_tag_cache(),
             key_format: self.key_format,
             serializer: self.serializer,
             compressor: self.compressor,
@@ -429,6 +441,7 @@ where
 
         MokaBackend {
             cache,
+            tags: build_tag_cache(),
             key_format: self.key_format,
             serializer: self.serializer,
             compressor: self.compressor,

--- a/hitbox-moka/tests/memory_eviction.rs
+++ b/hitbox-moka/tests/memory_eviction.rs
@@ -455,3 +455,52 @@ async fn test_explicit_tiny_lfu_policy_with_byte_capacity() {
         "Should have at most 3 entries with TinyLFU"
     );
 }
+
+// =============================================================================
+// Tag invalidation store is isolated from data eviction
+// =============================================================================
+
+/// Regression test: tag invalidation records must NOT share the data
+/// cache's eviction budget.
+///
+/// Without a dedicated tag store, writing enough data entries to trigger
+/// LRU eviction could evict a tag's invalidation record. A subsequent
+/// `invalidated()` lookup would then return nothing, and the FSM would
+/// incorrectly treat tagged entries as never invalidated — serving stale
+/// data. The dedicated unbounded tag store prevents this.
+#[tokio::test]
+async fn tag_records_survive_data_eviction_pressure() {
+    use hitbox_core::CacheTag;
+
+    // Data cache holds at most 2 entries.
+    let backend = MokaBackend::builder().max_entries(2).build();
+
+    let tag = CacheTag::new("user=42");
+    backend.invalidate(&tag).await.unwrap();
+
+    // Write far more data entries than the cache can hold, forcing
+    // repeated LRU eviction of data records.
+    for i in 0..100 {
+        let key = make_key(i);
+        let value = make_value(64);
+        backend.write(&key, value).await.unwrap();
+    }
+    backend.cache().run_pending_tasks().await;
+
+    // Data was evicted down to the 2-entry cap...
+    assert!(
+        backend.entry_count() <= 2,
+        "data cache should have evicted down to its 2-entry cap, got {}",
+        backend.entry_count()
+    );
+
+    // ...but the tag invalidation record must still be present.
+    let timestamps = backend
+        .invalidated(std::slice::from_ref(&tag))
+        .await
+        .unwrap();
+    assert!(
+        timestamps.contains_key(&tag),
+        "tag invalidation record was lost under data eviction pressure"
+    );
+}

--- a/hitbox-redis/src/backend.rs
+++ b/hitbox-redis/src/backend.rs
@@ -808,14 +808,19 @@ where
         let mut con = self.get_connection().await?.clone();
         let cache_key = self.key_format.serialize(key)?;
 
-        // Pipeline: HMGET (data, stale) + PTTL with typed decoding
-        let ((data, stale_ms), pttl): ((Option<Vec<u8>>, Option<i64>), i64) = con
+        // Pipeline: HMGET (data, stale, created, tags) + PTTL with typed decoding
+        let ((data, stale_ms, created_ms, tags_bytes), pttl): (
+            (Option<Vec<u8>>, Option<i64>, Option<i64>, Option<Vec<u8>>),
+            i64,
+        ) = con
             .query_pipeline(
                 redis::pipe()
                     .cmd("HMGET")
                     .arg(&cache_key)
                     .arg("d")
                     .arg("s")
+                    .arg("c")
+                    .arg("t")
                     .cmd("PTTL")
                     .arg(&cache_key),
             )
@@ -833,20 +838,40 @@ where
 
         // Calculate expire from PTTL (milliseconds remaining)
         // PTTL returns: -2 if key doesn't exist, -1 if no TTL, else milliseconds
-        let expire = (pttl > 0).then(|| Utc::now() + chrono::Duration::milliseconds(pttl));
+        let now = Utc::now();
+        let expire = (pttl > 0).then(|| now + chrono::Duration::milliseconds(pttl));
 
-        Ok(Some(CacheValue::new(data, expire, stale)))
+        // Restore created timestamp, fallback to epoch so any tag invalidation wins
+        let created = created_ms
+            .and_then(DateTime::from_timestamp_millis)
+            .unwrap_or(DateTime::UNIX_EPOCH);
+
+        // Restore tags if present
+        let tags = hitbox_backend::deserialize_tags(tags_bytes.as_deref())?;
+
+        let cv = CacheValue::with_created(data, created, expire, stale);
+        Ok(Some(match tags {
+            Some(tags) => cv.with_tags(tags),
+            None => cv,
+        }))
     }
 
     async fn write(&self, key: &CacheKey, value: CacheValue<Raw>) -> BackendResult<()> {
         let mut con = self.get_connection().await?.clone();
         let cache_key = self.key_format.serialize(key)?;
 
-        // Build HSET command with data field, optionally add stale field
+        // Build HSET command with data, created, and optionally stale/tags fields
         let mut cmd = redis::cmd("HSET");
-        cmd.arg(&cache_key).arg("d").arg(value.data().as_ref());
+        cmd.arg(&cache_key)
+            .arg("d")
+            .arg(value.data().as_ref())
+            .arg("c")
+            .arg(value.created().timestamp_millis());
         if let Some(stale) = value.stale() {
             cmd.arg("s").arg(stale.timestamp_millis());
+        }
+        if let Some(tags_bytes) = hitbox_backend::serialize_tags(value.tags())? {
+            cmd.arg("t").arg(tags_bytes);
         }
 
         // Pipeline: HSET + optional PEXPIRE (computed from value.ttl())

--- a/hitbox-test/benches/cache_future_reference.rs
+++ b/hitbox-test/benches/cache_future_reference.rs
@@ -219,6 +219,7 @@ fn create_policy() -> Arc<PolicyConfig> {
         stale: None,
         policy: Default::default(),
         concurrency: None,
+        tag_invalidation: Default::default(),
     }))
 }
 

--- a/hitbox-test/src/backend/mod.rs
+++ b/hitbox-test/src/backend/mod.rs
@@ -3,9 +3,10 @@ use std::future::Ready;
 use chrono::{DateTime, Utc};
 use hitbox_backend::format::FormatExt;
 use hitbox_backend::{Backend, CacheBackend, CacheKeyFormat, DeleteStatus};
+use hitbox_core::tag::{CacheTag, CacheTags, TagExtractor};
 use hitbox_core::{
     BoxContext, CacheContext, CacheKey, CachePolicy, CacheValue, CacheableResponse,
-    EntityPolicyConfig, ResponseCachePolicy,
+    EntityPolicyConfig, Predicate, ResponseCachePolicy,
 };
 use serde::{Deserialize, Serialize};
 
@@ -37,16 +38,21 @@ impl CacheableResponse for TestResponse {
     type IntoCachedFuture = Ready<CachePolicy<Self::Cached, Self>>;
     type FromCachedFuture = Ready<Self>;
 
-    async fn cache_policy<P>(
+    async fn cache_policy<P, TE>(
         self,
         _predicates: P,
+        _tag_extractor: TE,
         _config: &EntityPolicyConfig,
-    ) -> ResponseCachePolicy<Self>
+    ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where
-        P: hitbox_core::Predicate<Subject = Self::Subject> + Send + Sync,
+        P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
     {
         // Always cacheable for testing
-        CachePolicy::Cacheable(CacheValue::new(self.clone(), None, None))
+        (
+            CachePolicy::Cacheable(CacheValue::new(self.clone(), None, None)),
+            Vec::new(),
+        )
     }
 
     fn into_cached(self) -> Self::IntoCachedFuture {
@@ -81,6 +87,11 @@ pub async fn run_backend_tests<B: CacheBackend + Send + Sync>(backend: &B) {
     test_stale_metadata_exact_match(backend).await;
     test_expire_and_stale_combined(backend).await;
     test_no_metadata(backend).await;
+    test_tags_round_trip(backend).await;
+    test_request_only_tags_round_trip(backend).await;
+    test_invalidate_then_invalidated(backend).await;
+    test_invalidated_unknown_tags(backend).await;
+    test_invalidate_overwrites_timestamp(backend).await;
 }
 
 async fn test_write_and_read<B: CacheBackend>(backend: &B) {
@@ -469,6 +480,155 @@ async fn test_no_metadata<B: CacheBackend>(backend: &B) {
     assert_eq!(*cached.data(), response, "data should match");
     assert!(cached.expire().is_none(), "expire should be None");
     assert!(cached.stale().is_none(), "stale should be None");
+}
+
+// =============================================================================
+// Tag Storage and Invalidation Tests
+// =============================================================================
+
+async fn test_tags_round_trip<B: CacheBackend>(backend: &B) {
+    let key = CacheKey::from_str("test", "tags-both-sides");
+    let response = TestResponse::new(300, "tags-test", vec![1, 2, 3]);
+    let tags = CacheTags::new(
+        vec![CacheTag::new("user:42"), CacheTag::new("region:eu")],
+        vec![CacheTag::new("etag:abc123")],
+    );
+    let value = CacheValue::new(response.clone(), None, None).with_tags(tags.clone());
+
+    let mut ctx: BoxContext = CacheContext::default().boxed();
+    backend
+        .set::<TestResponse>(&key, &value, &mut ctx)
+        .await
+        .expect("failed to write");
+
+    let mut ctx: BoxContext = CacheContext::default().boxed();
+    let result: Option<CacheValue<TestResponse>> = backend
+        .get::<TestResponse>(&key, &mut ctx)
+        .await
+        .expect("failed to read");
+
+    assert!(result.is_some(), "value should exist");
+    let cached = result.unwrap();
+    assert_eq!(*cached.data(), response, "data should match");
+    let read_tags = cached.tags().expect("tags should be present");
+    assert_eq!(read_tags, &tags, "tags should round-trip identically");
+}
+
+async fn test_request_only_tags_round_trip<B: CacheBackend>(backend: &B) {
+    let key = CacheKey::from_str("test", "tags-request-only");
+    let response = TestResponse::new(301, "request-tags-test", vec![4, 5, 6]);
+    let tags = CacheTags::request_only(vec![CacheTag::new("tenant:7")]);
+    let value = CacheValue::new(response.clone(), None, None).with_tags(tags.clone());
+
+    let mut ctx: BoxContext = CacheContext::default().boxed();
+    backend
+        .set::<TestResponse>(&key, &value, &mut ctx)
+        .await
+        .expect("failed to write");
+
+    let mut ctx: BoxContext = CacheContext::default().boxed();
+    let result: Option<CacheValue<TestResponse>> = backend
+        .get::<TestResponse>(&key, &mut ctx)
+        .await
+        .expect("failed to read");
+
+    let cached = result.expect("value should exist");
+    let read_tags = cached.tags().expect("tags should be present");
+    assert_eq!(
+        read_tags.request,
+        Some(vec![CacheTag::new("tenant:7")]),
+        "request tags should round-trip"
+    );
+    assert_eq!(
+        read_tags.response, None,
+        "response side should remain None (unconfigured)"
+    );
+}
+
+async fn test_invalidate_then_invalidated<B: CacheBackend>(backend: &B) {
+    let tag = CacheTag::new("invalidate-test:basic");
+
+    // Compare at ms precision — backends may truncate timestamps to milliseconds.
+    let before = Utc::now().timestamp_millis();
+    backend
+        .invalidate(&tag)
+        .await
+        .expect("invalidate should succeed");
+    let after = Utc::now().timestamp_millis();
+
+    let timestamps = backend
+        .invalidated(std::slice::from_ref(&tag))
+        .await
+        .expect("invalidated lookup should succeed");
+
+    let ts = timestamps
+        .get(&tag)
+        .expect("timestamp should be present for invalidated tag")
+        .timestamp_millis();
+    assert!(
+        ts >= before && ts <= after,
+        "invalidation timestamp should fall within the call window (ms): ts={}, before={}, after={}",
+        ts,
+        before,
+        after
+    );
+}
+
+async fn test_invalidated_unknown_tags<B: CacheBackend>(backend: &B) {
+    let unknown = vec![
+        CacheTag::new("unknown:never-invalidated-1"),
+        CacheTag::new("unknown:never-invalidated-2"),
+    ];
+
+    let timestamps = backend
+        .invalidated(&unknown)
+        .await
+        .expect("invalidated lookup should succeed");
+
+    assert!(
+        timestamps.is_empty(),
+        "unknown tags should produce an empty map: got {:?}",
+        timestamps
+    );
+}
+
+async fn test_invalidate_overwrites_timestamp<B: CacheBackend>(backend: &B) {
+    let tag = CacheTag::new("invalidate-test:overwrite");
+
+    backend
+        .invalidate(&tag)
+        .await
+        .expect("first invalidate should succeed");
+    let first = backend
+        .invalidated(std::slice::from_ref(&tag))
+        .await
+        .expect("first lookup should succeed")
+        .get(&tag)
+        .copied()
+        .expect("first timestamp should be present");
+
+    // Sleep just enough to guarantee a strictly later timestamp regardless of
+    // backend storage precision (some backends store at ms precision).
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+    backend
+        .invalidate(&tag)
+        .await
+        .expect("second invalidate should succeed");
+    let second = backend
+        .invalidated(std::slice::from_ref(&tag))
+        .await
+        .expect("second lookup should succeed")
+        .get(&tag)
+        .copied()
+        .expect("second timestamp should be present");
+
+    assert!(
+        second > first,
+        "second invalidate should write a strictly later timestamp: first={:?}, second={:?}",
+        first,
+        second
+    );
 }
 
 /// Test UrlEncoded key + JSON value format

--- a/hitbox-test/src/backend/mod.rs
+++ b/hitbox-test/src/backend/mod.rs
@@ -41,7 +41,7 @@ impl CacheableResponse for TestResponse {
     async fn cache_policy<P, TE>(
         self,
         _predicates: P,
-        _tag_extractor: TE,
+        _tag_extractor: Option<TE>,
         _config: &EntityPolicyConfig,
     ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where

--- a/hitbox-test/src/core.rs
+++ b/hitbox-test/src/core.rs
@@ -5,6 +5,8 @@ use hitbox::Config;
 use hitbox::concurrency::BroadcastConcurrencyManager;
 use hitbox::offload::OffloadManager;
 use hitbox::policy::PolicyConfig;
+use hitbox::tag::TagExtractor;
+use hitbox_core::tag::NeutralTagExtractor;
 use hitbox_http::CacheableHttpRequest;
 use hitbox_http::CacheableHttpResponse;
 use hitbox_http::extractors::NeutralExtractor;
@@ -33,12 +35,18 @@ pub type BoxResponsePredicate =
     Box<dyn Predicate<Subject = CacheableHttpResponse<axum::body::Body>> + Send + Sync>;
 pub type BoxExtractor =
     Box<dyn Extractor<Subject = CacheableHttpRequest<axum::body::Body>> + Send + Sync>;
+pub type BoxRequestTagExtractor =
+    Box<dyn TagExtractor<Subject = CacheableHttpRequest<axum::body::Body>> + Send + Sync>;
+pub type BoxResponseTagExtractor =
+    Box<dyn TagExtractor<Subject = CacheableHttpResponse<axum::body::Body>> + Send + Sync>;
 
 /// Holds cache configuration components that can be modified by test steps.
 pub struct TestConfig {
     pub request_predicate: Arc<BoxRequestPredicate>,
     pub response_predicate: Arc<BoxResponsePredicate>,
     pub extractor: Arc<BoxExtractor>,
+    pub request_tag_extractor: Arc<BoxRequestTagExtractor>,
+    pub response_tag_extractor: Arc<BoxResponseTagExtractor>,
     pub policy: PolicyConfig,
 }
 
@@ -48,6 +56,8 @@ impl std::fmt::Debug for TestConfig {
             .field("request_predicate", &"...")
             .field("response_predicate", &"...")
             .field("extractor", &"...")
+            .field("request_tag_extractor", &"...")
+            .field("response_tag_extractor", &"...")
             .field("policy", &self.policy)
             .finish()
     }
@@ -59,6 +69,8 @@ impl Clone for TestConfig {
             request_predicate: Arc::clone(&self.request_predicate),
             response_predicate: Arc::clone(&self.response_predicate),
             extractor: Arc::clone(&self.extractor),
+            request_tag_extractor: Arc::clone(&self.request_tag_extractor),
+            response_tag_extractor: Arc::clone(&self.response_tag_extractor),
             policy: self.policy.clone(),
         }
     }
@@ -71,10 +83,18 @@ impl Default for TestConfig {
         let response_predicate: BoxResponsePredicate =
             Box::new(NeutralResponsePredicate::<axum::body::Body>::new());
         let extractor: BoxExtractor = Box::new(NeutralExtractor::<axum::body::Body>::new());
+        let request_tag_extractor: BoxRequestTagExtractor = Box::new(
+            NeutralTagExtractor::<CacheableHttpRequest<axum::body::Body>>::default(),
+        );
+        let response_tag_extractor: BoxResponseTagExtractor = Box::new(
+            NeutralTagExtractor::<CacheableHttpResponse<axum::body::Body>>::default(),
+        );
         Self {
             request_predicate: Arc::new(request_predicate),
             response_predicate: Arc::new(response_predicate),
             extractor: Arc::new(extractor),
+            request_tag_extractor: Arc::new(request_tag_extractor),
+            response_tag_extractor: Arc::new(response_tag_extractor),
             policy: PolicyConfig::default(),
         }
     }
@@ -83,11 +103,19 @@ impl Default for TestConfig {
 impl TestConfig {
     pub fn build(
         &self,
-    ) -> Config<Arc<BoxRequestPredicate>, Arc<BoxResponsePredicate>, Arc<BoxExtractor>> {
+    ) -> Config<
+        Arc<BoxRequestPredicate>,
+        Arc<BoxResponsePredicate>,
+        Arc<BoxExtractor>,
+        Arc<BoxRequestTagExtractor>,
+        Arc<BoxResponseTagExtractor>,
+    > {
         Config::builder()
             .request_predicate(Arc::clone(&self.request_predicate))
             .response_predicate(Arc::clone(&self.response_predicate))
             .extractor(Arc::clone(&self.extractor))
+            .request_tags(Arc::clone(&self.request_tag_extractor))
+            .response_tags(Arc::clone(&self.response_tag_extractor))
             .policy(self.policy.clone())
             .build()
     }

--- a/hitbox-test/src/core.rs
+++ b/hitbox-test/src/core.rs
@@ -83,12 +83,10 @@ impl Default for TestConfig {
         let response_predicate: BoxResponsePredicate =
             Box::new(NeutralResponsePredicate::<axum::body::Body>::new());
         let extractor: BoxExtractor = Box::new(NeutralExtractor::<axum::body::Body>::new());
-        let request_tag_extractor: BoxRequestTagExtractor = Box::new(
-            NeutralTagExtractor::<CacheableHttpRequest<axum::body::Body>>::default(),
-        );
-        let response_tag_extractor: BoxResponseTagExtractor = Box::new(
-            NeutralTagExtractor::<CacheableHttpResponse<axum::body::Body>>::default(),
-        );
+        let request_tag_extractor: BoxRequestTagExtractor =
+            Box::new(NeutralTagExtractor::<CacheableHttpRequest<axum::body::Body>>::default());
+        let response_tag_extractor: BoxResponseTagExtractor =
+            Box::new(NeutralTagExtractor::<CacheableHttpResponse<axum::body::Body>>::default());
         Self {
             request_predicate: Arc::new(request_predicate),
             response_predicate: Arc::new(response_predicate),

--- a/hitbox-test/src/fsm/world.rs
+++ b/hitbox-test/src/fsm/world.rs
@@ -32,12 +32,10 @@ pub struct SimpleRequest(pub u32);
 impl CacheableRequest for SimpleRequest {
     type CachePolicyFuture<'a, P, E, TE>
         = std::pin::Pin<
-            Box<
-                dyn std::future::Future<Output = (RequestCachePolicy<Self>, Vec<CacheTag>)>
-                    + Send
-                    + 'a,
-            >,
-        >
+        Box<
+            dyn std::future::Future<Output = (RequestCachePolicy<Self>, Vec<CacheTag>)> + Send + 'a,
+        >,
+    >
     where
         Self: 'a,
         P: Predicate<Subject = Self> + Send + Sync + 'a,
@@ -48,7 +46,7 @@ impl CacheableRequest for SimpleRequest {
         self,
         predicates: P,
         extractors: E,
-        tag_extractor: TE,
+        tag_extractor: Option<TE>,
     ) -> Self::CachePolicyFuture<'a, P, E, TE>
     where
         Self: 'a,
@@ -61,7 +59,10 @@ impl CacheableRequest for SimpleRequest {
                 PredicateResult::Cacheable(request) => {
                     let key_parts = extractors.get(request).await;
                     let (request, cache_key) = key_parts.into_cache_key();
-                    let (request, tags) = tag_extractor.extract_tags(request).await;
+                    let (request, tags) = match tag_extractor {
+                        Some(te) => te.extract_tags(request).await,
+                        None => (request, Vec::new()),
+                    };
                     (
                         RequestCachePolicy::Cacheable(CacheablePolicyData {
                             key: cache_key,
@@ -90,7 +91,7 @@ impl CacheableResponse for SimpleResponse {
     async fn cache_policy<P, TE>(
         self,
         predicates: P,
-        tag_extractor: TE,
+        tag_extractor: Option<TE>,
         _config: &EntityPolicyConfig,
     ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where
@@ -99,7 +100,10 @@ impl CacheableResponse for SimpleResponse {
     {
         match predicates.check(self).await {
             PredicateResult::Cacheable(response) => {
-                let (response, tags) = tag_extractor.extract_tags(response).await;
+                let (response, tags) = match tag_extractor {
+                    Some(te) => te.extract_tags(response).await,
+                    None => (response, Vec::new()),
+                };
                 (
                     CachePolicy::Cacheable(CacheValue::new(response.0, None, None)),
                     tags,
@@ -372,6 +376,7 @@ impl FsmWorld {
                 stale: self.config.stale,
                 concurrency: self.config.concurrency,
                 policy: Default::default(),
+                tag_invalidation: Default::default(),
             })
         } else {
             PolicyConfig::Disabled
@@ -494,6 +499,7 @@ impl FsmWorld {
                             stale: cfg.stale,
                             concurrency: cfg.concurrency,
                             policy: Default::default(),
+                            tag_invalidation: Default::default(),
                         })
                     } else {
                         PolicyConfig::Disabled

--- a/hitbox-test/src/fsm/world.rs
+++ b/hitbox-test/src/fsm/world.rs
@@ -12,6 +12,7 @@ use hitbox::{CacheContext, SelectiveConfig};
 use hitbox_backend::composition::CompositionPolicy;
 use hitbox_backend::composition::policy::RefillPolicy;
 use hitbox_backend::{CacheBackend, CompositionBackend};
+use hitbox_core::tag::{CacheTag, TagExtractor};
 use hitbox_core::{
     CacheKey, CachePolicy, CacheValue, CacheablePolicyData, CacheableRequest, CacheableResponse,
     EntityPolicyConfig, Extractor, KeyPart, KeyParts, Offload, Predicate, PredicateResult,
@@ -29,34 +30,49 @@ use crate::tracing::{SpanCollector, create_span_collector};
 pub struct SimpleRequest(pub u32);
 
 impl CacheableRequest for SimpleRequest {
-    type CachePolicyFuture<'a, P, E>
-        = std::pin::Pin<Box<dyn std::future::Future<Output = RequestCachePolicy<Self>> + Send + 'a>>
-    where
-        Self: 'a,
-        P: Predicate<Subject = Self> + Send + Sync + 'a,
-        E: Extractor<Subject = Self> + Send + Sync + 'a;
-
-    fn cache_policy<'a, P, E>(
-        self,
-        predicates: P,
-        extractors: E,
-    ) -> Self::CachePolicyFuture<'a, P, E>
+    type CachePolicyFuture<'a, P, E, TE>
+        = std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = (RequestCachePolicy<Self>, Vec<CacheTag>)>
+                    + Send
+                    + 'a,
+            >,
+        >
     where
         Self: 'a,
         P: Predicate<Subject = Self> + Send + Sync + 'a,
         E: Extractor<Subject = Self> + Send + Sync + 'a,
+        TE: TagExtractor<Subject = Self> + Send + Sync + 'a;
+
+    fn cache_policy<'a, P, E, TE>(
+        self,
+        predicates: P,
+        extractors: E,
+        tag_extractor: TE,
+    ) -> Self::CachePolicyFuture<'a, P, E, TE>
+    where
+        Self: 'a,
+        P: Predicate<Subject = Self> + Send + Sync + 'a,
+        E: Extractor<Subject = Self> + Send + Sync + 'a,
+        TE: TagExtractor<Subject = Self> + Send + Sync + 'a,
     {
         Box::pin(async move {
             match predicates.check(self).await {
                 PredicateResult::Cacheable(request) => {
                     let key_parts = extractors.get(request).await;
                     let (request, cache_key) = key_parts.into_cache_key();
-                    RequestCachePolicy::Cacheable(CacheablePolicyData {
-                        key: cache_key,
-                        request,
-                    })
+                    let (request, tags) = tag_extractor.extract_tags(request).await;
+                    (
+                        RequestCachePolicy::Cacheable(CacheablePolicyData {
+                            key: cache_key,
+                            request,
+                        }),
+                        tags,
+                    )
                 }
-                PredicateResult::NonCacheable(request) => RequestCachePolicy::NonCacheable(request),
+                PredicateResult::NonCacheable(request) => {
+                    (RequestCachePolicy::NonCacheable(request), Vec::new())
+                }
             }
         })
     }
@@ -71,19 +87,27 @@ impl CacheableResponse for SimpleResponse {
     type IntoCachedFuture = Ready<CachePolicy<Self::Cached, Self>>;
     type FromCachedFuture = Ready<Self>;
 
-    async fn cache_policy<P>(
+    async fn cache_policy<P, TE>(
         self,
         predicates: P,
+        tag_extractor: TE,
         _config: &EntityPolicyConfig,
-    ) -> ResponseCachePolicy<Self>
+    ) -> (ResponseCachePolicy<Self>, Vec<CacheTag>)
     where
         P: Predicate<Subject = Self::Subject> + Send + Sync,
+        TE: TagExtractor<Subject = Self::Subject> + Send + Sync,
     {
         match predicates.check(self).await {
             PredicateResult::Cacheable(response) => {
-                CachePolicy::Cacheable(CacheValue::new(response.0, None, None))
+                let (response, tags) = tag_extractor.extract_tags(response).await;
+                (
+                    CachePolicy::Cacheable(CacheValue::new(response.0, None, None)),
+                    tags,
+                )
             }
-            PredicateResult::NonCacheable(response) => CachePolicy::NonCacheable(response),
+            PredicateResult::NonCacheable(response) => {
+                (CachePolicy::NonCacheable(response), Vec::new())
+            }
         }
     }
 

--- a/hitbox-test/src/steps/given.rs
+++ b/hitbox-test/src/steps/given.rs
@@ -41,6 +41,22 @@ impl From<StalePolicy> for policy::StalePolicy {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
+enum TagInvalidation {
+    #[default]
+    Check,
+    Skip,
+}
+
+impl From<TagInvalidation> for policy::TagInvalidation {
+    fn from(t: TagInvalidation) -> Self {
+        match t {
+            TagInvalidation::Check => policy::TagInvalidation::Check,
+            TagInvalidation::Skip => policy::TagInvalidation::Skip,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct CacheBehaviorPolicy {
     #[serde(default)]
@@ -64,6 +80,8 @@ struct EnabledCacheConfig {
     #[serde(default)]
     policy: CacheBehaviorPolicy,
     concurrency: Option<NonZeroU8>,
+    #[serde(default)]
+    tag_invalidation: TagInvalidation,
 }
 
 impl Default for EnabledCacheConfig {
@@ -73,6 +91,7 @@ impl Default for EnabledCacheConfig {
             stale: None,
             policy: CacheBehaviorPolicy::default(),
             concurrency: None,
+            tag_invalidation: TagInvalidation::default(),
         }
     }
 }
@@ -84,6 +103,7 @@ impl From<EnabledCacheConfig> for policy::EnabledCacheConfig {
             stale: s.stale,
             policy: s.policy.into(),
             concurrency: s.concurrency,
+            tag_invalidation: s.tag_invalidation.into(),
         }
     }
 }

--- a/hitbox-test/src/steps/given.rs
+++ b/hitbox-test/src/steps/given.rs
@@ -2,10 +2,15 @@ use std::num::NonZeroU8;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::core::{BoxExtractor, HitboxWorld, StepExt};
+use crate::core::{
+    BoxExtractor, BoxRequestTagExtractor, BoxResponseTagExtractor, HitboxWorld, StepExt,
+};
 use crate::handler_state::HandlerName;
 use hitbox::offload::OffloadManager;
 use hitbox::policy;
+use hitbox_configuration::extractors::tag::{
+    self as tag_config, RequestTagExtractor, ResponseTagExtractor,
+};
 use hitbox_configuration::{Request, Response, extractors::Extractor};
 use hitbox_http::extractors::NeutralExtractor;
 
@@ -156,6 +161,34 @@ async fn key_extractors(world: &mut HitboxWorld, step: &Step) -> Result<(), Erro
         |inner, item| item.into_extractors(inner),
     )?;
     world.config.extractor = Arc::new(extractors);
+    Ok(())
+}
+
+#[given(expr = "tags")]
+async fn tags(world: &mut HitboxWorld, step: &Step) -> Result<(), Error> {
+    #[derive(Serialize, Deserialize, Default)]
+    struct Config {
+        #[serde(default)]
+        request: Vec<RequestTagExtractor>,
+        #[serde(default)]
+        response: Vec<ResponseTagExtractor>,
+    }
+    let config = serde_saphyr::from_str::<Config>(
+        step.docstring_content()
+            .ok_or(anyhow!("Missing tags configuration"))?
+            .as_str(),
+    )?;
+
+    if !config.request.is_empty() {
+        let request_tag_extractor: BoxRequestTagExtractor =
+            tag_config::request::build_request_boxed::<axum::body::Body>(config.request)?;
+        world.config.request_tag_extractor = Arc::new(request_tag_extractor);
+    }
+    if !config.response.is_empty() {
+        let response_tag_extractor: BoxResponseTagExtractor =
+            tag_config::build_response_boxed(config.response);
+        world.config.response_tag_extractor = Arc::new(response_tag_extractor);
+    }
     Ok(())
 }
 

--- a/hitbox-test/src/steps/when.rs
+++ b/hitbox-test/src/steps/when.rs
@@ -6,6 +6,8 @@ use chrono::Utc;
 use cucumber::gherkin::Step;
 use cucumber::when;
 use hitbox::concurrency::BroadcastConcurrencyManager;
+use hitbox::tag::CacheTag;
+use hitbox_backend::Backend;
 use hitbox_tower::Cache;
 use hurl::{
     runner::{VariableSet, request::eval_request},
@@ -40,6 +42,17 @@ async fn execute_request(world: &mut HitboxWorld, step: &Step) -> Result<(), Err
         .map_err(|err| anyhow!("hurl request error {:?}", err))?;
 
     world.execute_request(&request).await?;
+    Ok(())
+}
+
+#[when(expr = "tag {string} is invalidated")]
+async fn invalidate_tag(world: &mut HitboxWorld, tag: String) -> Result<(), Error> {
+    let cache_tag = CacheTag::new(tag);
+    world
+        .backend
+        .invalidate(&cache_tag)
+        .await
+        .map_err(|err| anyhow!("backend invalidate failed: {err:?}"))?;
     Ok(())
 }
 

--- a/hitbox-test/tests/features/tag_invalidation/tag_invalidation.feature
+++ b/hitbox-test/tests/features/tag_invalidation/tag_invalidation.feature
@@ -1,0 +1,245 @@
+Feature: Tag-Based Cache Invalidation
+
+  Verifies that tag extractors configured via the `tags:` section drive
+  cache invalidation correctly. Each scenario primes the cache with an
+  initial request, optionally invalidates a tag, then issues a second
+  request and asserts the resulting cache status.
+
+  Background:
+    Given hitbox with policy
+      ```yaml
+      Enabled:
+        ttl: 10s
+      ```
+
+  @tag-invalidation @miss
+  Scenario: Cache hit ignored when a request tag is invalidated
+    Given tags
+      """
+      request:
+        - Static:
+            user: "42"
+      """
+    # First request — cache miss, populates entry
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "MISS"
+    And GetBook should be called 1 time
+
+    # Invalidate the tag — write timestamp is now newer than entry.created
+    When sleep 20ms
+    And tag "user=42" is invalidated
+    And sleep 20ms
+
+    # Second request — must miss because of tag invalidation
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "MISS"
+    And GetBook should be called 2 times
+
+  @tag-invalidation @hit
+  Scenario: Cache hit served when no tag is invalidated
+    Given tags
+      """
+      request:
+        - Static:
+            user: "42"
+      """
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "MISS"
+    And GetBook should be called 1 time
+
+    # No invalidation — second request should hit
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "HIT"
+    And GetBook should be called 1 time
+
+  @tag-invalidation @hit
+  Scenario: Cache hit served when an unrelated tag is invalidated
+    Given tags
+      """
+      request:
+        - Static:
+            user: "42"
+      """
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "MISS"
+
+    # Invalidate a different tag — should not affect this entry
+    When sleep 20ms
+    And tag "user=99" is invalidated
+    And sleep 20ms
+
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "HIT"
+    And GetBook should be called 1 time
+
+  @tag-invalidation @miss
+  Scenario: Cache hit ignored when any of multiple request tags is invalidated
+    Given tags
+      """
+      request:
+        - Static:
+            user: "42"
+            region: "eu"
+      """
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "MISS"
+    And GetBook should be called 1 time
+
+    # Invalidate one of the two tags — entry must be treated as expired
+    When sleep 20ms
+    And tag "region=eu" is invalidated
+    And sleep 20ms
+
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "MISS"
+    And GetBook should be called 2 times
+
+  @tag-invalidation @hit
+  Scenario: No tag extractor configured — invalidation has no effect
+    # Default neutral tag extractor: request emits no tags, no parallel
+    # invalidation prefetch, behavior unchanged from non-tag flows.
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "MISS"
+    And GetBook should be called 1 time
+
+    # Even invalidating an arbitrary tag does nothing because the request
+    # extractor produces no tags to compare against.
+    When sleep 20ms
+    And tag "user=42" is invalidated
+    And sleep 20ms
+
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "HIT"
+    And GetBook should be called 1 time
+
+  # ============================================================================
+  # Compatibility layer: any Extractor variant can serve as a tag extractor
+  # via TagAdapter. Here Path emits author_id / book_id KeyParts; those become
+  # CacheTags of the form "author_id=robert-sheckley" / "book_id=victim-prime".
+  # ============================================================================
+
+  @tag-invalidation @miss @compat-layer
+  Scenario: Path extractor reused as tag extractor — invalidating path-derived tag misses
+    Given tags
+      """
+      request:
+        - Path: "/v1/authors/{author_id}/books/{book_id}"
+      """
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "MISS"
+    And GetBook should be called 1 time
+
+    # Invalidate one of the path-derived tags
+    When sleep 20ms
+    And tag "author_id=robert-sheckley" is invalidated
+    And sleep 20ms
+
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "MISS"
+    And GetBook should be called 2 times
+
+  @tag-invalidation @hit @compat-layer
+  Scenario: Path extractor as tag extractor — invalidating an unrelated path tag is a hit
+    Given tags
+      """
+      request:
+        - Path: "/v1/authors/{author_id}/books/{book_id}"
+      """
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "MISS"
+
+    # Invalidate a tag for a *different* author — should not affect this entry
+    When sleep 20ms
+    And tag "author_id=someone-else" is invalidated
+    And sleep 20ms
+
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "HIT"
+    And GetBook should be called 1 time
+
+  @tag-invalidation @miss @compat-layer
+  Scenario: Static + Path mixed — chained tag extractors all contribute to invalidation
+    Given tags
+      """
+      request:
+        - Static:
+            tier: "premium"
+        - Path: "/v1/authors/{author_id}/books/{book_id}"
+      """
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "MISS"
+    And GetBook should be called 1 time
+
+    # Invalidate the static tag — chain produced both static and path-derived
+    # tags; invalidating any one of them must miss.
+    When sleep 20ms
+    And tag "tier=premium" is invalidated
+    And sleep 20ms
+
+    When execute request
+      ```hurl
+      GET http://localhost/v1/authors/robert-sheckley/books/victim-prime
+      ```
+    Then response status is 200
+    And response header "X-Cache-Status" is "MISS"
+    And GetBook should be called 2 times

--- a/hitbox/src/config.rs
+++ b/hitbox/src/config.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use hitbox_core::Extractor;
 pub use hitbox_core::config::{CacheConfig, CacheConfigs};
 use hitbox_core::predicate::Predicate;
+use hitbox_core::tag::{NeutralTagExtractor, TagExtractor};
 
 use crate::policy::PolicyConfig;
 
@@ -16,6 +17,9 @@ pub type BoxPredicate<R> = Box<dyn Predicate<Subject = R> + Send + Sync>;
 
 /// Boxed extractor for dynamic dispatch.
 pub type BoxExtractor<Req> = Box<dyn Extractor<Subject = Req> + Send + Sync>;
+
+/// Boxed tag extractor for dynamic dispatch.
+pub type BoxTagExtractor<S> = Box<dyn TagExtractor<Subject = S> + Send + Sync>;
 
 /// Generic cache configuration.
 ///
@@ -46,48 +50,69 @@ pub type BoxExtractor<Req> = Box<dyn Extractor<Subject = Req> + Send + Sync>;
 ///     .extractor(FixedKeyExtractor)
 ///     .policy(PolicyConfig::builder().ttl(Duration::from_secs(60)).build())
 ///     .build();
-/// # let _: Config<Neutral<String>, Neutral<String>, FixedKeyExtractor> = config;
+/// # let _: Config<
+/// #     Neutral<String>,
+/// #     Neutral<String>,
+/// #     FixedKeyExtractor,
+/// #     hitbox_core::tag::NeutralTagExtractor<String>,
+/// #     hitbox_core::tag::NeutralTagExtractor<String>,
+/// # > = config;
 /// ```
-pub struct Config<ReqPred, ResPred, Ext> {
+pub struct Config<ReqPred, ResPred, Ext, ReqTagExt, ResTagExt> {
     request_predicate: Arc<ReqPred>,
     response_predicate: Arc<ResPred>,
     extractor: Arc<Ext>,
+    request_tag_extractors: Arc<ReqTagExt>,
+    response_tag_extractors: Arc<ResTagExt>,
     policy: Arc<PolicyConfig>,
 }
 
-impl<ReqPred, ResPred, Ext> Clone for Config<ReqPred, ResPred, Ext> {
+impl<ReqPred, ResPred, Ext, ReqTagExt, ResTagExt> Clone
+    for Config<ReqPred, ResPred, Ext, ReqTagExt, ResTagExt>
+{
     fn clone(&self) -> Self {
         Self {
             request_predicate: Arc::clone(&self.request_predicate),
             response_predicate: Arc::clone(&self.response_predicate),
             extractor: Arc::clone(&self.extractor),
+            request_tag_extractors: Arc::clone(&self.request_tag_extractors),
+            response_tag_extractors: Arc::clone(&self.response_tag_extractors),
             policy: Arc::clone(&self.policy),
         }
     }
 }
 
-impl<ReqPred, ResPred, Ext> std::fmt::Debug for Config<ReqPred, ResPred, Ext> {
+impl<ReqPred, ResPred, Ext, ReqTagExt, ResTagExt> std::fmt::Debug
+    for Config<ReqPred, ResPred, Ext, ReqTagExt, ResTagExt>
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Config")
             .field("request_predicate", &"...")
             .field("response_predicate", &"...")
             .field("extractor", &"...")
+            .field("request_tag_extractors", &"...")
+            .field("response_tag_extractors", &"...")
             .field("policy", &self.policy)
             .finish()
     }
 }
 
-impl<Req, Res, ReqPred, ResPred, Ext> CacheConfig<Req, Res> for Config<ReqPred, ResPred, Ext>
+impl<Req, Res, ReqPred, ResPred, Ext, ReqTagExt, ResTagExt> CacheConfig<Req, Res>
+    for Config<ReqPred, ResPred, Ext, ReqTagExt, ResTagExt>
 where
     Req: Send,
     Res: Send,
     ReqPred: Predicate<Subject = Req> + Send + Sync + 'static,
     ResPred: Predicate<Subject = Res> + Send + Sync + 'static,
     Ext: Extractor<Subject = Req> + Send + Sync + 'static,
+    ReqTagExt: TagExtractor<Subject = Req> + Send + Sync + 'static,
+    ResTagExt: TagExtractor<Subject = Res> + Send + Sync + 'static,
 {
     type RequestPredicate = Arc<ReqPred>;
     type ResponsePredicate = Arc<ResPred>;
     type Extractor = Arc<Ext>;
+    type RequestTagExtractor = Arc<ReqTagExt>;
+    type ResponseTagExtractor = Arc<ResTagExt>;
 
     fn request_predicates(&self) -> Self::RequestPredicate {
         Arc::clone(&self.request_predicate)
@@ -101,18 +126,29 @@ where
         Arc::clone(&self.extractor)
     }
 
+    fn request_tag_extractors(&self) -> Self::RequestTagExtractor {
+        Arc::clone(&self.request_tag_extractors)
+    }
+
+    fn response_tag_extractors(&self) -> Self::ResponseTagExtractor {
+        Arc::clone(&self.response_tag_extractors)
+    }
+
     fn policy(&self) -> Arc<PolicyConfig> {
         Arc::clone(&self.policy)
     }
 }
 
-impl<Req, Res, ReqPred, ResPred, Ext> CacheConfigs<Req, Res> for Config<ReqPred, ResPred, Ext>
+impl<Req, Res, ReqPred, ResPred, Ext, ReqTagExt, ResTagExt> CacheConfigs<Req, Res>
+    for Config<ReqPred, ResPred, Ext, ReqTagExt, ResTagExt>
 where
     Req: Send,
     Res: Send,
     ReqPred: Predicate<Subject = Req> + Send + Sync + 'static,
     ResPred: Predicate<Subject = Res> + Send + Sync + 'static,
     Ext: Extractor<Subject = Req> + Send + Sync + 'static,
+    ReqTagExt: TagExtractor<Subject = Req> + Send + Sync + 'static,
+    ResTagExt: TagExtractor<Subject = Res> + Send + Sync + 'static,
 {
     type Config = Self;
 
@@ -160,10 +196,12 @@ where
 /// Builder for [`Config`].
 ///
 /// Use [`Config::builder()`] to create a new builder.
-pub struct ConfigBuilder<ReqPred, ResPred, Ext> {
+pub struct ConfigBuilder<ReqPred, ResPred, Ext, ReqTagExt, ResTagExt> {
     request_predicate: ReqPred,
     response_predicate: ResPred,
     extractor: Ext,
+    request_tag_extractors: ReqTagExt,
+    response_tag_extractors: ResTagExt,
     policy: PolicyConfig,
 }
 
@@ -174,41 +212,80 @@ pub struct ConfigBuilder<ReqPred, ResPred, Ext> {
 /// the corresponding builder method yet.
 pub struct NotSet;
 
-impl Config<NotSet, NotSet, NotSet> {
+/// Trait for converting builder tag-extractor slots into a concrete tag extractor.
+///
+/// This implements option (d) for default tag extractors: when the builder
+/// reaches `.build()`, the `Subject` type is inferred from the predicate's
+/// associated type, and `NotSet` is materialized as `NeutralTagExtractor<Subject>`.
+/// Real tag extractors pass through unchanged.
+pub trait MaybeTagExtractor<Subject> {
+    /// The resolved tag extractor type.
+    type Output: TagExtractor<Subject = Subject> + Send + Sync + 'static;
+    /// Convert the builder slot into the concrete tag extractor.
+    fn into_tag_extractor(self) -> Self::Output;
+}
+
+impl<Subject> MaybeTagExtractor<Subject> for NotSet
+where
+    Subject: Send + 'static,
+{
+    type Output = NeutralTagExtractor<Subject>;
+    fn into_tag_extractor(self) -> Self::Output {
+        NeutralTagExtractor::default()
+    }
+}
+
+impl<T, Subject> MaybeTagExtractor<Subject> for T
+where
+    T: TagExtractor<Subject = Subject> + Send + Sync + 'static,
+{
+    type Output = T;
+    fn into_tag_extractor(self) -> Self::Output {
+        self
+    }
+}
+
+impl Config<NotSet, NotSet, NotSet, NotSet, NotSet> {
     /// Creates a new [`ConfigBuilder`].
-    pub fn builder() -> ConfigBuilder<NotSet, NotSet, NotSet> {
+    pub fn builder() -> ConfigBuilder<NotSet, NotSet, NotSet, NotSet, NotSet> {
         ConfigBuilder::new()
     }
 }
 
-impl ConfigBuilder<NotSet, NotSet, NotSet> {
+impl ConfigBuilder<NotSet, NotSet, NotSet, NotSet, NotSet> {
     /// Creates a new builder with no fields set.
     pub fn new() -> Self {
         Self {
             request_predicate: NotSet,
             response_predicate: NotSet,
             extractor: NotSet,
+            request_tag_extractors: NotSet,
+            response_tag_extractors: NotSet,
             policy: PolicyConfig::default(),
         }
     }
 }
 
-impl Default for ConfigBuilder<NotSet, NotSet, NotSet> {
+impl Default for ConfigBuilder<NotSet, NotSet, NotSet, NotSet, NotSet> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<ReqPred, ResPred, Ext> ConfigBuilder<ReqPred, ResPred, Ext> {
+impl<ReqPred, ResPred, Ext, ReqTagExt, ResTagExt>
+    ConfigBuilder<ReqPred, ResPred, Ext, ReqTagExt, ResTagExt>
+{
     /// Sets the request predicate.
     pub fn request_predicate<NewReqPred>(
         self,
         predicate: NewReqPred,
-    ) -> ConfigBuilder<NewReqPred, ResPred, Ext> {
+    ) -> ConfigBuilder<NewReqPred, ResPred, Ext, ReqTagExt, ResTagExt> {
         ConfigBuilder {
             request_predicate: predicate,
             response_predicate: self.response_predicate,
             extractor: self.extractor,
+            request_tag_extractors: self.request_tag_extractors,
+            response_tag_extractors: self.response_tag_extractors,
             policy: self.policy,
         }
     }
@@ -217,21 +294,58 @@ impl<ReqPred, ResPred, Ext> ConfigBuilder<ReqPred, ResPred, Ext> {
     pub fn response_predicate<NewResPred>(
         self,
         predicate: NewResPred,
-    ) -> ConfigBuilder<ReqPred, NewResPred, Ext> {
+    ) -> ConfigBuilder<ReqPred, NewResPred, Ext, ReqTagExt, ResTagExt> {
         ConfigBuilder {
             request_predicate: self.request_predicate,
             response_predicate: predicate,
             extractor: self.extractor,
+            request_tag_extractors: self.request_tag_extractors,
+            response_tag_extractors: self.response_tag_extractors,
             policy: self.policy,
         }
     }
 
     /// Sets the cache key extractor.
-    pub fn extractor<NewExt>(self, extractor: NewExt) -> ConfigBuilder<ReqPred, ResPred, NewExt> {
+    pub fn extractor<NewExt>(
+        self,
+        extractor: NewExt,
+    ) -> ConfigBuilder<ReqPred, ResPred, NewExt, ReqTagExt, ResTagExt> {
         ConfigBuilder {
             request_predicate: self.request_predicate,
             response_predicate: self.response_predicate,
             extractor,
+            request_tag_extractors: self.request_tag_extractors,
+            response_tag_extractors: self.response_tag_extractors,
+            policy: self.policy,
+        }
+    }
+
+    /// Sets the request tag extractor (for request-side cache invalidation).
+    pub fn request_tags<NewReqTagExt>(
+        self,
+        tag_extractor: NewReqTagExt,
+    ) -> ConfigBuilder<ReqPred, ResPred, Ext, NewReqTagExt, ResTagExt> {
+        ConfigBuilder {
+            request_predicate: self.request_predicate,
+            response_predicate: self.response_predicate,
+            extractor: self.extractor,
+            request_tag_extractors: tag_extractor,
+            response_tag_extractors: self.response_tag_extractors,
+            policy: self.policy,
+        }
+    }
+
+    /// Sets the response tag extractor (for response-side cache invalidation).
+    pub fn response_tags<NewResTagExt>(
+        self,
+        tag_extractor: NewResTagExt,
+    ) -> ConfigBuilder<ReqPred, ResPred, Ext, ReqTagExt, NewResTagExt> {
+        ConfigBuilder {
+            request_predicate: self.request_predicate,
+            response_predicate: self.response_predicate,
+            extractor: self.extractor,
+            request_tag_extractors: self.request_tag_extractors,
+            response_tag_extractors: tag_extractor,
             policy: self.policy,
         }
     }
@@ -242,21 +356,30 @@ impl<ReqPred, ResPred, Ext> ConfigBuilder<ReqPred, ResPred, Ext> {
     }
 }
 
-impl<ReqPred, ResPred, Ext> ConfigBuilder<ReqPred, ResPred, Ext>
+impl<ReqPred, ResPred, Ext, ReqTagExt, ResTagExt>
+    ConfigBuilder<ReqPred, ResPred, Ext, ReqTagExt, ResTagExt>
 where
     ReqPred: Predicate + Send + Sync + 'static,
     ResPred: Predicate + Send + Sync + 'static,
     Ext: Extractor + Send + Sync + 'static,
+    ReqTagExt: MaybeTagExtractor<ReqPred::Subject>,
+    ResTagExt: MaybeTagExtractor<ResPred::Subject>,
+    ReqPred::Subject: Send + 'static,
+    ResPred::Subject: Send + 'static,
 {
     /// Builds the [`Config`].
     ///
-    /// All fields (request_predicate, response_predicate, extractor) must be set
-    /// before calling this method.
-    pub fn build(self) -> Config<ReqPred, ResPred, Ext> {
+    /// Required fields (`request_predicate`, `response_predicate`, `extractor`) must be set.
+    /// Tag extractors default to [`NeutralTagExtractor`] if not configured.
+    pub fn build(
+        self,
+    ) -> Config<ReqPred, ResPred, Ext, ReqTagExt::Output, ResTagExt::Output> {
         Config {
             request_predicate: Arc::new(self.request_predicate),
             response_predicate: Arc::new(self.response_predicate),
             extractor: Arc::new(self.extractor),
+            request_tag_extractors: Arc::new(self.request_tag_extractors.into_tag_extractor()),
+            response_tag_extractors: Arc::new(self.response_tag_extractors.into_tag_extractor()),
             policy: Arc::new(self.policy),
         }
     }

--- a/hitbox/src/config.rs
+++ b/hitbox/src/config.rs
@@ -371,9 +371,7 @@ where
     ///
     /// Required fields (`request_predicate`, `response_predicate`, `extractor`) must be set.
     /// Tag extractors default to [`NeutralTagExtractor`] if not configured.
-    pub fn build(
-        self,
-    ) -> Config<ReqPred, ResPred, Ext, ReqTagExt::Output, ResTagExt::Output> {
+    pub fn build(self) -> Config<ReqPred, ResPred, Ext, ReqTagExt::Output, ResTagExt::Output> {
         Config {
             request_predicate: Arc::new(self.request_predicate),
             response_predicate: Arc::new(self.response_predicate),

--- a/hitbox/src/fsm/future.rs
+++ b/hitbox/src/fsm/future.rs
@@ -13,6 +13,7 @@ use std::{
 
 use crate::{CacheContext, CacheStatus, CacheableResponse, ResponseSource};
 use futures::ready;
+use hitbox_core::tag::{NeutralTagExtractor, TagExtractor};
 use hitbox_core::{Cacheable, DisabledOffload, Offload, OffloadKey, Upstream};
 use pin_project::pin_project;
 use tracing::{Level, Span, debug, span, trace};
@@ -31,23 +32,41 @@ const POLL_AFTER_READY_ERROR: &str = "CacheFuture can't be polled after finishin
 /// Drives the state machine through: request predicate check → cache lookup →
 /// upstream call (on miss) → response predicate check → cache update → response.
 #[pin_project(project = CacheFutureProj)]
-pub struct CacheFuture<'offload, B, Req, Res, U, ReqP, ResP, E, C, O = DisabledOffload>
+pub struct CacheFuture<
+    'offload,
+    B,
+    Req,
+    Res,
+    U,
+    ReqP,
+    ResP,
+    E,
+    C,
+    O = DisabledOffload,
+    ReqTE = NeutralTagExtractor<Req>,
+    ResTE = NeutralTagExtractor<<Res as CacheableResponse>::Subject>,
+>
 where
     U: Upstream<Req, Response = Res>,
     B: CacheBackend,
     Res: CacheableResponse,
-    Req: CacheableRequest,
+    Res::Cached: Send,
+    Res: Send,
+    Req: CacheableRequest + Send,
     ReqP: Predicate<Subject = Req> + Send + Sync,
     ResP: Predicate<Subject = Res::Subject> + Send + Sync,
     E: Extractor<Subject = Req> + Send + Sync,
     C: ConcurrencyManager<Res>,
     O: Offload<'offload>,
+    ReqTE: TagExtractor<Subject = Req> + Send + Sync,
+    ResTE: TagExtractor<Subject = Res::Subject> + Send + Sync,
 {
     backend: Arc<B>,
     cache_key: Option<CacheKey>,
     #[pin]
-    state: State<'offload, Res, Req, U, ReqP, E>,
+    state: State<'offload, Res, Req, U, ReqP, E, ReqTE>,
     response_predicates: Option<ResP>,
+    response_tag_extractors: Option<ResTE>,
     policy: Arc<crate::policy::PolicyConfig>,
     /// Offload for background revalidation (SWR).
     /// Use `DisabledOffload` (the default) to disable background revalidation.
@@ -64,19 +83,39 @@ where
 }
 
 impl<'offload, B, Req, Res, U, ReqP, ResP, E, C, O>
-    CacheFuture<'offload, B, Req, Res, U, ReqP, ResP, E, C, O>
+    CacheFuture<
+        'offload,
+        B,
+        Req,
+        Res,
+        U,
+        ReqP,
+        ResP,
+        E,
+        C,
+        O,
+        NeutralTagExtractor<Req>,
+        NeutralTagExtractor<<Res as CacheableResponse>::Subject>,
+    >
 where
     U: Upstream<Req, Response = Res>,
     B: CacheBackend,
     Res: CacheableResponse,
-    Req: CacheableRequest,
+    Res::Cached: Send,
+    Res: Send,
+    Req: CacheableRequest + Send,
     ReqP: Predicate<Subject = Req> + Send + Sync,
     ResP: Predicate<Subject = Res::Subject> + Send + Sync,
     E: Extractor<Subject = Req> + Send + Sync,
     C: ConcurrencyManager<Res>,
     O: Offload<'offload>,
 {
-    /// Creates a new cache future with full configuration.
+    /// Creates a new cache future with no tag invalidation.
+    ///
+    /// Uses [`NeutralTagExtractor`] for both request and response tags. Use
+    /// [`new_with_tags`] to enable tag invalidation.
+    ///
+    /// [`new_with_tags`]: Self::new_with_tags
     pub fn new(
         backend: Arc<B>,
         request: Req,
@@ -88,11 +127,59 @@ where
         offload: O,
         concurrency_manager: C,
     ) -> Self {
+        Self::new_with_tags(
+            backend,
+            request,
+            upstream,
+            request_predicates,
+            response_predicates,
+            key_extractors,
+            NeutralTagExtractor::default(),
+            NeutralTagExtractor::default(),
+            policy,
+            offload,
+            concurrency_manager,
+        )
+    }
+}
+
+impl<'offload, B, Req, Res, U, ReqP, ResP, E, C, O, ReqTE, ResTE>
+    CacheFuture<'offload, B, Req, Res, U, ReqP, ResP, E, C, O, ReqTE, ResTE>
+where
+    U: Upstream<Req, Response = Res>,
+    B: CacheBackend,
+    Res: CacheableResponse,
+    Res::Cached: Send,
+    Res: Send,
+    Req: CacheableRequest + Send,
+    ReqP: Predicate<Subject = Req> + Send + Sync,
+    ResP: Predicate<Subject = Res::Subject> + Send + Sync,
+    E: Extractor<Subject = Req> + Send + Sync,
+    C: ConcurrencyManager<Res>,
+    O: Offload<'offload>,
+    ReqTE: TagExtractor<Subject = Req> + Send + Sync,
+    ResTE: TagExtractor<Subject = Res::Subject> + Send + Sync,
+{
+    /// Creates a new cache future with explicit request and response tag extractors.
+    pub fn new_with_tags(
+        backend: Arc<B>,
+        request: Req,
+        upstream: U,
+        request_predicates: ReqP,
+        response_predicates: ResP,
+        key_extractors: E,
+        request_tag_extractors: ReqTE,
+        response_tag_extractors: ResTE,
+        policy: Arc<crate::policy::PolicyConfig>,
+        offload: O,
+        concurrency_manager: C,
+    ) -> Self {
         let parent_span = span!(Level::DEBUG, "hitbox.cache");
         let initial_state = states::Initial::new(
             request,
             request_predicates,
             key_extractors,
+            request_tag_extractors,
             CacheContext::default().boxed(),
             upstream,
             &parent_span,
@@ -102,6 +189,7 @@ where
             cache_key: None,
             state: State::Initial(Some(initial_state)),
             response_predicates: Some(response_predicates),
+            response_tag_extractors: Some(response_tag_extractors),
             policy,
             offload,
             is_revalidation: false,
@@ -125,13 +213,17 @@ impl<'offload, B, Req, Res, U, ReqP, ResP, E>
         E,
         NoopConcurrencyManager,
         hitbox_core::DisabledOffload,
+        NeutralTagExtractor<Req>,
+        NeutralTagExtractor<<Res as CacheableResponse>::Subject>,
     >
 where
     U: Upstream<Req, Response = Res>,
     U::Future: Send + 'offload,
     B: CacheBackend,
     Res: CacheableResponse,
-    Req: CacheableRequest,
+    Res::Cached: Send,
+    Res: Send,
+    Req: CacheableRequest + Send,
     ReqP: Predicate<Subject = Req> + Send + Sync,
     ResP: Predicate<Subject = Res::Subject> + Send + Sync,
     E: Extractor<Subject = Req> + Send + Sync,
@@ -178,6 +270,7 @@ where
                 state: Some(state),
             },
             response_predicates: Some(response_predicates),
+            response_tag_extractors: Some(NeutralTagExtractor::default()),
             policy,
             // Revalidation tasks don't spawn further revalidation
             offload: DisabledOffload,
@@ -191,43 +284,55 @@ where
     }
 }
 
-impl<'offload, B, Req, Res, U, ReqP, ResP, E, C, O>
-    CacheFuture<'offload, B, Req, Res, U, ReqP, ResP, E, C, O>
+impl<'offload, B, Req, Res, U, ReqP, ResP, E, C, O, ReqTE, ResTE>
+    CacheFuture<'offload, B, Req, Res, U, ReqP, ResP, E, C, O, ReqTE, ResTE>
 where
     U: Upstream<Req, Response = Res>,
     B: CacheBackend + Send + Sync + 'static,
     Res: CacheableResponse,
     Res::Cached: Cacheable + Send,
-    Req: CacheableRequest,
+    Req: CacheableRequest + Send,
     ReqP: Predicate<Subject = Req> + Send + Sync,
     ResP: Predicate<Subject = Res::Subject> + Send + Sync,
     E: Extractor<Subject = Req> + Send + Sync,
     C: ConcurrencyManager<Res>,
     O: Offload<'offload>,
+    ReqTE: TagExtractor<Subject = Req> + Send + Sync,
+    ResTE: TagExtractor<Subject = Res::Subject> + Send + Sync,
 {
     /// Create a CacheFuture starting at `PollCache` state, skipping predicate
     /// evaluation and key extraction.
     ///
-    /// Used by [`SelectiveCacheFuture`](super::SelectiveCacheFuture) after the routing FSM has already evaluated
-    /// request predicates and extracted the cache key.
+    /// Used by [`SelectiveCacheFuture`](super::SelectiveCacheFuture) after the
+    /// routing FSM has already evaluated request predicates and extracted the
+    /// cache key. Pre-extracted request tags are checked in parallel with the
+    /// cache read; the response tag extractor is applied at write time
+    /// (see [`CheckResponseCachePolicy`](states::CheckResponseCachePolicy)).
     ///
-    /// Note: `ReqP` and `E` are phantom types in this path — the FSM starts
-    /// past the states that use them (same pattern as [`revalidate`](Self::revalidate)).
+    /// For the no-tags case, pass an empty `request_tags` Vec and
+    /// [`NeutralTagExtractor`] — the parallel tag fetch is skipped entirely
+    /// when tags are empty.
+    #[allow(clippy::too_many_arguments)]
     pub fn poll_cache(
         backend: Arc<B>,
         cache_key: CacheKey,
         request: Req,
         upstream: U,
         response_predicates: ResP,
+        request_tags: Vec<hitbox_core::tag::CacheTag>,
+        response_tag_extractor: ResTE,
         policy: Arc<crate::policy::PolicyConfig>,
         offload: O,
         concurrency_manager: C,
-    ) -> Self {
+    ) -> Self
+    where
+        ResTE: 'static,
+    {
         let parent_span = span!(Level::DEBUG, "hitbox.cache");
         let cache_key_for_get = cache_key.clone();
         let backend_for_get = backend.clone();
         let mut ctx = CacheContext::default().boxed();
-        let poll_cache = Box::pin(async move {
+        let cache_future = Box::pin(async move {
             let result = backend_for_get
                 .get::<Res>(&cache_key_for_get, &mut ctx)
                 .await;
@@ -237,6 +342,17 @@ where
             );
             (result, ctx)
         });
+
+        // Build tag invalidation future only when request tags are present.
+        let tag_future: Option<states::TagInvalidationFuture> = if request_tags.is_empty() {
+            None
+        } else {
+            let backend_for_tags = backend.clone();
+            Some(Box::pin(async move {
+                backend_for_tags.invalidated(&request_tags).await
+            }))
+        };
+        let poll_cache = states::PollCacheWithTagsFuture::new(cache_future, tag_future);
         let poll_cache_state =
             states::PollCache::new(request, cache_key.clone(), upstream, &parent_span);
 
@@ -248,6 +364,7 @@ where
                 state: Some(poll_cache_state),
             },
             response_predicates: Some(response_predicates),
+            response_tag_extractors: Some(response_tag_extractor),
             policy,
             offload,
             is_revalidation: false,
@@ -259,8 +376,8 @@ where
     }
 }
 
-impl<'offload, B, Req, Res, U, ReqP, ResP, E, C, O> Future
-    for CacheFuture<'offload, B, Req, Res, U, ReqP, ResP, E, C, O>
+impl<'offload, B, Req, Res, U, ReqP, ResP, E, C, O, ReqTE, ResTE> Future
+    for CacheFuture<'offload, B, Req, Res, U, ReqP, ResP, E, C, O, ReqTE, ResTE>
 where
     U: Upstream<Req, Response = Res> + Send + 'offload,
     U::Future: Send + 'offload,
@@ -273,6 +390,8 @@ where
     E: Extractor<Subject = Req> + Send + Sync + 'offload,
     C: ConcurrencyManager<Res> + 'static,
     O: Offload<'offload>,
+    ReqTE: TagExtractor<Subject = Req> + Send + Sync + 'offload,
+    ResTE: TagExtractor<Subject = Res::Subject> + Send + Sync + 'static,
 {
     type Output = (Res, CacheContext);
 
@@ -294,22 +413,28 @@ where
                 } => {
                     let state_ref = state.as_ref().expect(POLL_AFTER_READY_ERROR);
                     trace!(parent: &state_ref.span, "FSM state: CheckRequestCachePolicy");
-                    let policy = ready!(cache_policy_future.poll(cx));
+                    let (policy, request_tags) = ready!(cache_policy_future.poll(cx));
                     let check_state = state.take().expect(POLL_AFTER_READY_ERROR);
 
                     check_state
-                        .transition(policy, this.backend.clone(), this.cache_key)
+                        .transition(
+                            policy,
+                            request_tags,
+                            this.backend.clone(),
+                            this.cache_key,
+                        )
                         .into_state(&*this.span)
                 }
                 StateProj::PollCache { poll_cache, state } => {
                     let state_ref = state.as_ref().expect(POLL_AFTER_READY_ERROR);
                     trace!(parent: &state_ref.span, "FSM state: PollCache");
-                    let (cache_result, ctx) = ready!(poll_cache.poll(cx));
+                    let (cache_result, tag_invalidation, ctx) = ready!(poll_cache.poll(cx));
                     let poll_cache_state = state.take().expect(POLL_AFTER_READY_ERROR);
 
                     poll_cache_state
                         .transition(
                             cache_result,
+                            tag_invalidation,
                             ctx,
                             this.backend.clone(),
                             this.policy.as_ref(),
@@ -400,9 +525,18 @@ where
                         .response_predicates
                         .take()
                         .expect("Response predicates already taken");
+                    let response_tag_extractor = this
+                        .response_tag_extractors
+                        .take()
+                        .expect("Response tag extractor already taken");
 
                     poll_upstream
-                        .transition(upstream_result, predicates, this.policy.as_ref())
+                        .transition(
+                            upstream_result,
+                            predicates,
+                            response_tag_extractor,
+                            this.policy.as_ref(),
+                        )
                         .into_state(&*this.span)
                 }
                 StateProj::CheckResponseCachePolicy {
@@ -411,11 +545,16 @@ where
                 } => {
                     let state_ref = state.as_ref().expect(POLL_AFTER_READY_ERROR);
                     trace!(parent: &state_ref.span, "FSM state: CheckResponseCachePolicy");
-                    let policy = ready!(cache_policy.poll(cx));
+                    let (policy, response_tags) = ready!(cache_policy.poll(cx));
                     let check_state = state.take().expect(POLL_AFTER_READY_ERROR);
 
                     check_state
-                        .transition(policy, this.backend.clone(), &*this.concurrency_manager)
+                        .transition(
+                            policy,
+                            response_tags,
+                            this.backend.clone(),
+                            &*this.concurrency_manager,
+                        )
                         .into_state(&*this.span)
                 }
                 StateProj::UpdateCache {

--- a/hitbox/src/fsm/future.rs
+++ b/hitbox/src/fsm/future.rs
@@ -45,8 +45,7 @@ pub struct CacheFuture<
     O = DisabledOffload,
     ReqTE = NeutralTagExtractor<Req>,
     ResTE = NeutralTagExtractor<<Res as CacheableResponse>::Subject>,
->
-where
+> where
     U: Upstream<Req, Response = Res>,
     B: CacheBackend,
     Res: CacheableResponse,
@@ -329,30 +328,15 @@ where
         ResTE: 'static,
     {
         let parent_span = span!(Level::DEBUG, "hitbox.cache");
-        let cache_key_for_get = cache_key.clone();
-        let backend_for_get = backend.clone();
-        let mut ctx = CacheContext::default().boxed();
-        let cache_future = Box::pin(async move {
-            let result = backend_for_get
-                .get::<Res>(&cache_key_for_get, &mut ctx)
-                .await;
-            debug!(
-                found = result.as_ref().map(|r| r.is_some()).unwrap_or(false),
-                "FSM cache lookup result"
-            );
-            (result, ctx)
-        });
-
-        // Build tag invalidation future only when request tags are present.
-        let tag_future: Option<states::TagInvalidationFuture> = if request_tags.is_empty() {
-            None
-        } else {
-            let backend_for_tags = backend.clone();
-            Some(Box::pin(async move {
-                backend_for_tags.invalidated(&request_tags).await
-            }))
-        };
-        let poll_cache = states::PollCacheWithTagsFuture::new(cache_future, tag_future);
+        let ctx = CacheContext::default().boxed();
+        let tag_invalidation_enabled = policy.tag_invalidation_enabled();
+        let poll_cache = states::PollCacheWithTagsFuture::build::<Res, B>(
+            backend.clone(),
+            cache_key.clone(),
+            ctx,
+            request_tags,
+            tag_invalidation_enabled,
+        );
         let poll_cache_state =
             states::PollCache::new(request, cache_key.clone(), upstream, &parent_span);
 
@@ -416,11 +400,13 @@ where
                     let (policy, request_tags) = ready!(cache_policy_future.poll(cx));
                     let check_state = state.take().expect(POLL_AFTER_READY_ERROR);
 
+                    let tag_invalidation_enabled = this.policy.tag_invalidation_enabled();
                     check_state
                         .transition(
                             policy,
                             request_tags,
                             this.backend.clone(),
+                            tag_invalidation_enabled,
                             this.cache_key,
                         )
                         .into_state(&*this.span)

--- a/hitbox/src/fsm/selective/mod.rs
+++ b/hitbox/src/fsm/selective/mod.rs
@@ -40,6 +40,10 @@ type ResPredOf<CC, Req, Res> =
     <ConfigOf<CC, Req, Res> as CacheConfig<Req, ResSubject<Res>>>::ResponsePredicate;
 type ExtractorOf<CC, Req, Res> =
     <ConfigOf<CC, Req, Res> as CacheConfig<Req, ResSubject<Res>>>::Extractor;
+type ReqTagExtractorOf<CC, Req, Res> =
+    <ConfigOf<CC, Req, Res> as CacheConfig<Req, ResSubject<Res>>>::RequestTagExtractor;
+type ResTagExtractorOf<CC, Req, Res> =
+    <ConfigOf<CC, Req, Res> as CacheConfig<Req, ResSubject<Res>>>::ResponseTagExtractor;
 
 /// Type alias for the inner CacheFuture constructed by the selective FSM.
 #[allow(clippy::type_complexity)]
@@ -54,6 +58,8 @@ pub(crate) type InnerCacheFuture<'offload, B, Req, Res, CC, U, CM, O> = CacheFut
     ExtractorOf<CC, Req, Res>,
     CM,
     O,
+    ReqTagExtractorOf<CC, Req, Res>,
+    ResTagExtractorOf<CC, Req, Res>,
 >;
 
 /// Future that selectively applies caching based on multi-config predicate matching.
@@ -90,7 +96,8 @@ where
     U: Upstream<Req, Response = Res>,
     B: CacheBackend,
     Res: CacheableResponse,
-    Req: CacheableRequest,
+    Res::Cached: Send,
+    Req: CacheableRequest + Send,
     CC: CacheConfigs<Req, ResSubject<Res>>,
     CM: ConcurrencyManager<Res>,
     O: Offload<'offload>,
@@ -117,6 +124,7 @@ where
     U: Upstream<Req, Response = Res>,
     B: CacheBackend,
     Res: CacheableResponse,
+    Res::Cached: Send,
     Req: CacheableRequest + Send + 'offload,
     CC: CacheConfigs<Req, ResSubject<Res>>,
     CM: ConcurrencyManager<Res>,
@@ -226,11 +234,13 @@ where
                 } => {
                     let extract = state.as_ref().expect(POLL_AFTER_READY);
                     trace!(parent: &extract.span, "FSM state: ExtractKey");
-                    let key_parts = ready!(extract_future.poll(cx));
+                    let (request, cache_key, request_tags) = ready!(extract_future.poll(cx));
                     let extract = state.take().expect(POLL_AFTER_READY);
                     extract
                         .transition(
-                            key_parts,
+                            request,
+                            cache_key,
+                            request_tags,
                             &*this.configs,
                             this.backend.clone(),
                             &mut *this.upstream,

--- a/hitbox/src/fsm/selective/states.rs
+++ b/hitbox/src/fsm/selective/states.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 use futures::future::BoxFuture;
 use hitbox_core::tag::{CacheTag, TagExtractor as _};
 use hitbox_core::{
-    CacheConfigs, CacheKey, Cacheable, Extractor as _, Offload, Predicate as _,
-    PredicateResult, Upstream,
+    CacheConfigs, CacheKey, Cacheable, Extractor as _, Offload, Predicate as _, PredicateResult,
+    Upstream,
 };
 use pin_project::pin_project;
 use tracing::{Level, Span, debug, field, span, trace};

--- a/hitbox/src/fsm/selective/states.rs
+++ b/hitbox/src/fsm/selective/states.rs
@@ -9,9 +9,10 @@
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
+use hitbox_core::tag::{CacheTag, TagExtractor as _};
 use hitbox_core::{
-    CacheConfigs, Cacheable, Extractor as _, KeyParts, Offload, Predicate as _, PredicateResult,
-    Upstream,
+    CacheConfigs, CacheKey, Cacheable, Extractor as _, Offload, Predicate as _,
+    PredicateResult, Upstream,
 };
 use pin_project::pin_project;
 use tracing::{Level, Span, debug, field, span, trace};
@@ -39,10 +40,10 @@ pub enum SelectiveState<'a, Inner, Req, UF> {
         predicate_future: BoxFuture<'a, PredicateResult<Req>>,
         state: Option<CheckPredicate>,
     },
-    /// Matched config — extracting cache key.
+    /// Matched config — extracting cache key and request tags.
     ExtractKey {
         #[pin]
-        extract_future: BoxFuture<'a, KeyParts<Req>>,
+        extract_future: BoxFuture<'a, (Req, CacheKey, Vec<CacheTag>)>,
         state: Option<ExtractKey>,
     },
     /// Running inner CacheFuture from PollCache state.
@@ -112,10 +113,16 @@ impl CheckPredicate {
                 trace!(
                     parent: &self.span,
                     config_index = self.config_index,
-                    "Config matched, extracting cache key"
+                    "Config matched, extracting cache key and request tags"
                 );
                 let ext = configs.configs()[self.config_index].extractors();
-                let extract_future = Box::pin(async move { ext.get(request).await });
+                let tag_ext = configs.configs()[self.config_index].request_tag_extractors();
+                let extract_future = Box::pin(async move {
+                    let key_parts = ext.get(request).await;
+                    let (request, cache_key) = key_parts.into_cache_key();
+                    let (request, request_tags) = tag_ext.extract_tags(request).await;
+                    (request, cache_key, request_tags)
+                });
                 CheckPredicateTransition::ExtractKey {
                     extract_future,
                     config_index: self.config_index,
@@ -192,11 +199,16 @@ impl ExtractKey {
 
     /// Transition from ExtractKey state after extract future completes.
     ///
-    /// Always delegates to CacheFuture starting at PollCache state.
+    /// Receives the request, cache key, and request tags from the extract
+    /// future, and delegates to CacheFuture starting at PollCache state with
+    /// request tags pre-attached for parallel invalidation prefetch and
+    /// the response tag extractor from the matched config.
     #[allow(clippy::type_complexity)]
     pub fn transition<'offload, B, Req, Res, CC, U, CM, O>(
         self,
-        key_parts: KeyParts<Req>,
+        request: Req,
+        cache_key: CacheKey,
+        request_tags: Vec<CacheTag>,
         configs: &CC,
         backend: Arc<B>,
         upstream: &mut Option<U>,
@@ -214,19 +226,21 @@ impl ExtractKey {
         CM: ConcurrencyManager<Res> + 'static,
         O: Offload<'offload>,
     {
-        let (request, cache_key) = key_parts.into_cache_key();
         self.span
             .record("cache.key", cache_key.to_string().as_str());
         debug!(
             parent: &self.span,
             config_index = self.config_index,
             cache.key = %cache_key,
+            request_tags = request_tags.len(),
             "Cache key extracted, delegating to CacheFuture"
         );
 
         let upstream = upstream.take().expect(TAKE_ERROR);
-        let response_predicates = configs.configs()[self.config_index].response_predicates();
-        let policy = configs.configs()[self.config_index].policy();
+        let config = &configs.configs()[self.config_index];
+        let response_predicates = config.response_predicates();
+        let response_tag_extractor = config.response_tag_extractors();
+        let policy = config.policy();
         let offload = offload.take().expect(TAKE_ERROR);
         let concurrency_manager = concurrency_manager.take().expect(TAKE_ERROR);
 
@@ -236,6 +250,8 @@ impl ExtractKey {
             request,
             upstream,
             response_predicates,
+            request_tags,
+            response_tag_extractor,
             policy,
             offload,
             concurrency_manager,

--- a/hitbox/src/fsm/selective/transitions.rs
+++ b/hitbox/src/fsm/selective/transitions.rs
@@ -6,7 +6,8 @@
 #![allow(missing_docs)]
 
 use futures::future::BoxFuture;
-use hitbox_core::{KeyParts, PredicateResult};
+use hitbox_core::tag::CacheTag;
+use hitbox_core::{CacheKey, PredicateResult};
 use tracing::Span;
 
 use super::states::{CheckPredicate, ExtractKey, Passthrough, SelectiveState};
@@ -17,9 +18,9 @@ use super::states::{CheckPredicate, ExtractKey, Passthrough, SelectiveState};
 
 /// Transitions from CheckPredicate state.
 pub enum CheckPredicateTransition<'a, Req, UF> {
-    /// Request matched — extract cache key from this config.
+    /// Request matched — extract cache key and request tags from this config.
     ExtractKey {
-        extract_future: BoxFuture<'a, KeyParts<Req>>,
+        extract_future: BoxFuture<'a, (Req, CacheKey, Vec<CacheTag>)>,
         config_index: usize,
     },
     /// Request did not match — try the next enabled config.

--- a/hitbox/src/fsm/states.rs
+++ b/hitbox/src/fsm/states.rs
@@ -14,7 +14,7 @@ use std::task::{Context, Poll};
 use std::time::Instant;
 
 use chrono::{DateTime, Utc};
-use futures::future::BoxFuture;
+use futures::future::{BoxFuture, join};
 use futures::ready;
 use hitbox_backend::BackendError;
 use hitbox_core::tag::{CacheTag, CacheTags};
@@ -64,51 +64,98 @@ pub type PollCacheFuture<T> = BoxFuture<'static, (CacheResult<T>, BoxContext)>;
 pub type UpdateCacheFuture<T> = BoxFuture<'static, (Result<(), BackendError>, T, BoxContext)>;
 pub type AwaitResponseFuture<T> = BoxFuture<'static, Result<T, ConcurrencyError>>;
 /// Future that checks request cache policy and extracts request tags
-pub type RequestCachePolicyFuture<'a, T> =
-    BoxFuture<'a, (RequestCachePolicy<T>, Vec<CacheTag>)>;
+pub type RequestCachePolicyFuture<'a, T> = BoxFuture<'a, (RequestCachePolicy<T>, Vec<CacheTag>)>;
 
 /// Result of querying tag invalidation timestamps from the backend.
 pub type TagInvalidationResult = Result<HashMap<CacheTag, DateTime<Utc>>, BackendError>;
-
-/// Future that fetches tag invalidation timestamps.
-pub type TagInvalidationFuture = BoxFuture<'static, TagInvalidationResult>;
 
 // =============================================================================
 // PollCacheWithTagsFuture - parallel cache + tag fetch
 // =============================================================================
 
-/// Future that polls the cache read and tag invalidation check in parallel.
+/// Future that polls the cache read together with tag-invalidation checks.
 ///
-/// When `tag_future` is `None` (no tags configured), this degrades to a simple
-/// cache read with zero overhead — the tag future is never polled.
+/// Request-side tag invalidation (tags known before the read) runs
+/// concurrently with the cache read. Response-side tag invalidation is
+/// *lazy*: only after a cache hit, and only if the stored entry carries
+/// response tags, a second `invalidated()` query runs for them — its
+/// timestamps are merged into the same map the FSM scans. Both sides are
+/// skipped entirely when `tag_invalidation_enabled` is false (no
+/// `invalidated()` round-trips at all).
 ///
-/// On cache miss or backend error, short-circuits without waiting for tag results.
-#[pin_project]
+/// On a cache miss the response-tag query is never issued (nothing to
+/// check); a request-tag query already in flight still resolves.
 pub struct PollCacheWithTagsFuture<T> {
-    #[pin]
-    cache_future: Option<PollCacheFuture<T>>,
-    #[pin]
-    tag_future: Option<TagInvalidationFuture>,
-    /// Stored cache result when it completes before tags.
-    cache_result: Option<(CacheResult<T>, BoxContext)>,
-    /// Stored tag result when it completes before cache.
-    tag_result: Option<TagInvalidationResult>,
+    inner: BoxFuture<'static, (CacheResult<T>, Option<TagInvalidationResult>, BoxContext)>,
 }
 
 impl<T> PollCacheWithTagsFuture<T> {
-    /// Create with both cache and optional tag invalidation futures.
-    pub fn new(cache_future: PollCacheFuture<T>, tag_future: Option<TagInvalidationFuture>) -> Self {
-        Self {
-            cache_future: Some(cache_future),
-            tag_future,
-            cache_result: None,
-            tag_result: None,
-        }
+    /// Build the combined cache-read + tag-invalidation future.
+    ///
+    /// `tag_invalidation_enabled` gates both sides: when false, no tag
+    /// queries are issued and the cache read is returned as-is.
+    pub fn build<Res, B>(
+        backend: Arc<B>,
+        cache_key: CacheKey,
+        mut ctx: BoxContext,
+        request_tags: Vec<CacheTag>,
+        tag_invalidation_enabled: bool,
+    ) -> Self
+    where
+        Res: CacheableResponse<Cached = T> + Send + 'static,
+        Res::Cached: Cacheable + Send,
+        B: CacheBackend + Send + Sync + 'static,
+        T: Send + 'static,
+    {
+        let inner = Box::pin(async move {
+            let check = tag_invalidation_enabled;
+            let want_req = check && !request_tags.is_empty();
+
+            // Cache read + (optional) request-tag query, concurrently.
+            let (cache_result, req_tag_result): (CacheResult<T>, Option<TagInvalidationResult>) = {
+                let get_fut = backend.get::<Res>(&cache_key, &mut ctx);
+                if want_req {
+                    let (c, t) = join(get_fut, backend.invalidated(&request_tags)).await;
+                    (c, Some(t))
+                } else {
+                    (get_fut.await, None)
+                }
+            };
+
+            // Lazy response-tag check: only on a hit, only when enabled,
+            // only if the stored entry actually carries response tags.
+            let tag_result = if !check {
+                None
+            } else if let Ok(Some(ref cached_value)) = cache_result {
+                let resp_tags = cached_value
+                    .tags()
+                    .and_then(|t| t.response.clone())
+                    .unwrap_or_default();
+                if resp_tags.is_empty() {
+                    req_tag_result
+                } else {
+                    let resp = backend.invalidated(&resp_tags).await;
+                    Some(merge_tag_results(req_tag_result, resp))
+                }
+            } else {
+                req_tag_result
+            };
+
+            (cache_result, tag_result, ctx)
+        });
+        Self { inner }
     }
 
-    /// Create without tag checking (zero overhead path).
-    pub fn without_tags(cache_future: PollCacheFuture<T>) -> Self {
-        Self::new(cache_future, None)
+    /// Build a cache-only future — no tag invalidation, zero overhead.
+    pub fn without_tags(cache_future: PollCacheFuture<T>) -> Self
+    where
+        T: Send + 'static,
+    {
+        let inner = Box::pin(async move {
+            let (result, ctx) = cache_future.await;
+            (result, None, ctx)
+        });
+        Self { inner }
     }
 }
 
@@ -116,53 +163,38 @@ impl<T> std::future::Future for PollCacheWithTagsFuture<T> {
     type Output = (CacheResult<T>, Option<TagInvalidationResult>, BoxContext);
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut this = self.project();
+        self.get_mut().inner.as_mut().poll(cx)
+    }
+}
 
-        // Poll cache future if not yet done.
-        // We use `as_pin_mut` to get `Pin<&mut Option<F>>`, then poll the future inside.
-        if this.cache_future.is_some() {
-            // SAFETY: cache_future is Some, project to inner PollCacheFuture
-            let mut fut = this.cache_future.as_mut();
-            // Pin<&mut Option<F>> → poll the future inside
-            // BoxFuture is Unpin, so we can poll it via Pin::new on the inner ref
-            if let Some(inner) = fut.as_mut().as_pin_mut() {
-                if let Poll::Ready((cache_result, ctx)) = inner.poll(cx) {
-                    fut.set(None);
-
-                    // Short-circuit: on cache miss or error, skip tag check entirely
-                    let is_miss_or_error =
-                        cache_result.as_ref().map(Option::is_none).unwrap_or(true);
-                    if is_miss_or_error {
-                        this.tag_future.set(None);
-                        return Poll::Ready((cache_result, None, ctx));
-                    }
-
-                    // If no tag future was configured, return immediately
-                    if this.tag_future.is_none() {
-                        return Poll::Ready((cache_result, None, ctx));
-                    }
-
-                    // Hold cache result while tag future completes
-                    *this.cache_result = Some((cache_result, ctx));
-                }
+/// Merge request-side and response-side tag-invalidation results.
+///
+/// Any backend error propagates — the FSM treats an errored invalidation
+/// check as a forced miss. Otherwise the timestamp maps are unioned,
+/// keeping the latest timestamp per tag.
+fn merge_tag_results(
+    request: Option<TagInvalidationResult>,
+    response: TagInvalidationResult,
+) -> TagInvalidationResult {
+    let mut map = match request {
+        None => HashMap::new(),
+        Some(Ok(m)) => m,
+        Some(Err(e)) => return Err(e),
+    };
+    match response {
+        Ok(resp_map) => {
+            for (tag, ts) in resp_map {
+                map.entry(tag)
+                    .and_modify(|e| {
+                        if ts > *e {
+                            *e = ts;
+                        }
+                    })
+                    .or_insert(ts);
             }
+            Ok(map)
         }
-
-        // Poll tag future if present and not yet done
-        if this.tag_future.is_some() {
-            let mut fut = this.tag_future.as_mut();
-            if let Some(inner) = fut.as_mut().as_pin_mut() {
-                if let Poll::Ready(result) = inner.poll(cx) {
-                    fut.set(None);
-                    if let Some((cache_result, ctx)) = this.cache_result.take() {
-                        return Poll::Ready((cache_result, Some(result), ctx));
-                    }
-                    *this.tag_result = Some(result);
-                }
-            }
-        }
-
-        Poll::Pending
+        Err(e) => Err(e),
     }
 }
 
@@ -363,7 +395,11 @@ where
                 let request = self.request;
                 let predicates = self.predicates;
                 let extractors = self.extractors;
-                let tag_extractor = self.tag_extractor;
+                // `None` skips request-tag extraction entirely (no extractor
+                // future is constructed) when invalidation is disabled.
+                let tag_extractor = policy
+                    .tag_invalidation_enabled()
+                    .then_some(self.tag_extractor);
                 let cache_policy_future = Box::pin(async move {
                     request
                         .cache_policy(predicates, extractors, tag_extractor)
@@ -513,6 +549,11 @@ impl PollUpstream {
                     },
                     PolicyConfig::Disabled => EntityPolicyConfig::default(),
                 };
+                // `None` skips response-tag extraction entirely (no extractor
+                // future is constructed) when invalidation is disabled.
+                let response_tag_extractor = policy
+                    .tag_invalidation_enabled()
+                    .then_some(response_tag_extractor);
                 PollUpstreamTransition::CheckResponseCachePolicy {
                     cache_policy_future: Box::pin(async move {
                         let (policy, tags) = upstream_result
@@ -619,7 +660,9 @@ impl CheckResponseCachePolicy {
                 let mut ctx = self.ctx;
                 // Attach response tags before write if any were extracted.
                 let cache_value = match response_tags {
-                    Some(response_tags) => cache_value.with_tags(CacheTags::response_only(response_tags)),
+                    Some(response_tags) => {
+                        cache_value.with_tags(CacheTags::response_only(response_tags))
+                    }
                     None => cache_value,
                 };
                 let update_cache_future = Box::pin(async move {
@@ -683,11 +726,16 @@ impl<U> CheckRequestCachePolicy<U> {
     }
 
     /// Transition from CheckRequestCachePolicy state after future completes.
+    ///
+    /// `tag_invalidation_enabled` gates the read-time invalidation queries
+    /// (request-tag prefetch and the lazy response-tag check). When false,
+    /// the cache read is returned without any `invalidated()` round-trips.
     pub fn transition<Req, Res, B>(
         self,
         policy: RequestCachePolicy<Req>,
         request_tags: Vec<CacheTag>,
         backend: Arc<B>,
+        tag_invalidation_enabled: bool,
         cache_key_storage: &mut Option<CacheKey>,
     ) -> CheckRequestCachePolicyTransition<Req, Res, U>
     where
@@ -704,28 +752,15 @@ impl<U> CheckRequestCachePolicy<U> {
         );
         match policy {
             CachePolicy::Cacheable(CacheablePolicyData { key, request }) => {
-                let cache_key_for_get = key.clone();
                 debug!(?key, "FSM looking up cache key");
                 let _ = cache_key_storage.insert(key.clone());
-                let mut ctx = self.ctx;
-                let backend_for_tags = backend.clone();
-                let cache_future = Box::pin(async move {
-                    let result = backend.get::<Res>(&cache_key_for_get, &mut ctx).await;
-                    debug!(
-                        found = result.as_ref().map(|r| r.is_some()).unwrap_or(false),
-                        "FSM cache lookup result"
-                    );
-                    (result, ctx)
-                });
-                // Build tag invalidation future only if there are request tags to check
-                let tag_future: Option<TagInvalidationFuture> = if request_tags.is_empty() {
-                    None
-                } else {
-                    Some(Box::pin(async move {
-                        backend_for_tags.invalidated(&request_tags).await
-                    }))
-                };
-                let poll_cache = PollCacheWithTagsFuture::new(cache_future, tag_future);
+                let poll_cache = PollCacheWithTagsFuture::build::<Res, B>(
+                    backend,
+                    key.clone(),
+                    self.ctx,
+                    request_tags,
+                    tag_invalidation_enabled,
+                );
                 CheckRequestCachePolicyTransition::PollCache {
                     poll_cache,
                     request,
@@ -815,8 +850,7 @@ impl<Req, U> PollCache<Req, U> {
                     match tag_result {
                         Ok(timestamps) if !timestamps.is_empty() => {
                             let entry_created = cached_value.created();
-                            let invalidated =
-                                timestamps.values().any(|&ts| ts > entry_created);
+                            let invalidated = timestamps.values().any(|&ts| ts > entry_created);
                             if invalidated {
                                 debug!(
                                     "Cache entry invalidated by tag (created={}, latest_tag_ts={:?})",
@@ -834,11 +868,7 @@ impl<Req, U> PollCache<Req, U> {
                         Err(err) => {
                             warn!("Tag invalidation check failed: {err:?}");
                             ctx.set_status(CacheStatus::Miss);
-                            return self.transition_to_upstream(
-                                ctx,
-                                policy,
-                                concurrency_manager,
-                            );
+                            return self.transition_to_upstream(ctx, policy, concurrency_manager);
                         }
                         _ => {}
                     }

--- a/hitbox/src/fsm/states.rs
+++ b/hitbox/src/fsm/states.rs
@@ -6,15 +6,18 @@
 //!
 //! Flow: poll future → create state struct → `.transition()` → `.into_state()`
 
+use std::collections::HashMap;
 use std::fmt::{self, Debug};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
 
+use chrono::{DateTime, Utc};
 use futures::future::BoxFuture;
 use futures::ready;
 use hitbox_backend::BackendError;
+use hitbox_core::tag::{CacheTag, CacheTags};
 use hitbox_core::{
     BoxContext, CachePolicy, CacheValue, Cacheable, CacheablePolicyData, EntityPolicyConfig,
     Predicate, ReadMode, RequestCachePolicy, ResponseCachePolicy, Upstream,
@@ -32,6 +35,7 @@ use crate::fsm::transitions::{
 };
 use crate::policy::{EnabledCacheConfig, PolicyConfig, StalePolicy};
 use crate::{CacheKey, CacheState, CacheStatus, CacheableRequest, CacheableResponse, Extractor};
+use hitbox_core::tag::TagExtractor;
 
 // =============================================================================
 // Helper Types
@@ -54,13 +58,113 @@ impl fmt::Display for OptionalKey<'_> {
 // =============================================================================
 
 pub type CacheResult<T> = Result<Option<CacheValue<T>>, BackendError>;
-/// Future that polls the cache and returns (result, context)
+/// Future that polls the cache and returns (result, context).
 pub type PollCacheFuture<T> = BoxFuture<'static, (CacheResult<T>, BoxContext)>;
-/// Future that updates the cache and returns (backend_result, response, context)
+/// Future that updates the cache and returns (backend_result, response, context).
 pub type UpdateCacheFuture<T> = BoxFuture<'static, (Result<(), BackendError>, T, BoxContext)>;
 pub type AwaitResponseFuture<T> = BoxFuture<'static, Result<T, ConcurrencyError>>;
-/// Future that checks request cache policy
-pub type RequestCachePolicyFuture<'a, T> = BoxFuture<'a, RequestCachePolicy<T>>;
+/// Future that checks request cache policy and extracts request tags
+pub type RequestCachePolicyFuture<'a, T> =
+    BoxFuture<'a, (RequestCachePolicy<T>, Vec<CacheTag>)>;
+
+/// Result of querying tag invalidation timestamps from the backend.
+pub type TagInvalidationResult = Result<HashMap<CacheTag, DateTime<Utc>>, BackendError>;
+
+/// Future that fetches tag invalidation timestamps.
+pub type TagInvalidationFuture = BoxFuture<'static, TagInvalidationResult>;
+
+// =============================================================================
+// PollCacheWithTagsFuture - parallel cache + tag fetch
+// =============================================================================
+
+/// Future that polls the cache read and tag invalidation check in parallel.
+///
+/// When `tag_future` is `None` (no tags configured), this degrades to a simple
+/// cache read with zero overhead — the tag future is never polled.
+///
+/// On cache miss or backend error, short-circuits without waiting for tag results.
+#[pin_project]
+pub struct PollCacheWithTagsFuture<T> {
+    #[pin]
+    cache_future: Option<PollCacheFuture<T>>,
+    #[pin]
+    tag_future: Option<TagInvalidationFuture>,
+    /// Stored cache result when it completes before tags.
+    cache_result: Option<(CacheResult<T>, BoxContext)>,
+    /// Stored tag result when it completes before cache.
+    tag_result: Option<TagInvalidationResult>,
+}
+
+impl<T> PollCacheWithTagsFuture<T> {
+    /// Create with both cache and optional tag invalidation futures.
+    pub fn new(cache_future: PollCacheFuture<T>, tag_future: Option<TagInvalidationFuture>) -> Self {
+        Self {
+            cache_future: Some(cache_future),
+            tag_future,
+            cache_result: None,
+            tag_result: None,
+        }
+    }
+
+    /// Create without tag checking (zero overhead path).
+    pub fn without_tags(cache_future: PollCacheFuture<T>) -> Self {
+        Self::new(cache_future, None)
+    }
+}
+
+impl<T> std::future::Future for PollCacheWithTagsFuture<T> {
+    type Output = (CacheResult<T>, Option<TagInvalidationResult>, BoxContext);
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        // Poll cache future if not yet done.
+        // We use `as_pin_mut` to get `Pin<&mut Option<F>>`, then poll the future inside.
+        if this.cache_future.is_some() {
+            // SAFETY: cache_future is Some, project to inner PollCacheFuture
+            let mut fut = this.cache_future.as_mut();
+            // Pin<&mut Option<F>> → poll the future inside
+            // BoxFuture is Unpin, so we can poll it via Pin::new on the inner ref
+            if let Some(inner) = fut.as_mut().as_pin_mut() {
+                if let Poll::Ready((cache_result, ctx)) = inner.poll(cx) {
+                    fut.set(None);
+
+                    // Short-circuit: on cache miss or error, skip tag check entirely
+                    let is_miss_or_error =
+                        cache_result.as_ref().map(Option::is_none).unwrap_or(true);
+                    if is_miss_or_error {
+                        this.tag_future.set(None);
+                        return Poll::Ready((cache_result, None, ctx));
+                    }
+
+                    // If no tag future was configured, return immediately
+                    if this.tag_future.is_none() {
+                        return Poll::Ready((cache_result, None, ctx));
+                    }
+
+                    // Hold cache result while tag future completes
+                    *this.cache_result = Some((cache_result, ctx));
+                }
+            }
+        }
+
+        // Poll tag future if present and not yet done
+        if this.tag_future.is_some() {
+            let mut fut = this.tag_future.as_mut();
+            if let Some(inner) = fut.as_mut().as_pin_mut() {
+                if let Poll::Ready(result) = inner.poll(cx) {
+                    fut.set(None);
+                    if let Some((cache_result, ctx)) = this.cache_result.take() {
+                        return Poll::Ready((cache_result, Some(result), ctx));
+                    }
+                    *this.tag_result = Some(result);
+                }
+            }
+        }
+
+        Poll::Pending
+    }
+}
 
 // =============================================================================
 // ConvertResponseFuture - Zero-cost wrapper using GAT
@@ -104,26 +208,27 @@ impl<Res: CacheableResponse> std::future::Future for ConvertResponseFuture<Res> 
 
 #[allow(missing_docs)]
 #[pin_project(project = StateProj)]
-pub enum State<'req, Res, Req, U, ReqP, E>
+pub enum State<'req, Res, Req, U, ReqP, E, ReqTE>
 where
     Res: CacheableResponse,
     Req: CacheableRequest + 'req,
     U: Upstream<Req, Response = Res> + 'req,
     ReqP: Predicate<Subject = Req>,
     E: Extractor<Subject = Req>,
+    ReqTE: TagExtractor<Subject = Req>,
 {
     /// Initial state - all data needed for the first transition
-    Initial(Option<Initial<Req, ReqP, E, U>>),
-    /// Checking if request should be cached
+    Initial(Option<Initial<Req, ReqP, E, U, ReqTE>>),
+    /// Checking if request should be cached (also extracts request tags)
     CheckRequestCachePolicy {
         #[pin]
         cache_policy_future: RequestCachePolicyFuture<'req, Req>,
         state: Option<CheckRequestCachePolicy<U>>,
     },
-    /// Polling the cache backend - context is captured in the future
+    /// Polling the cache backend and tag invalidation in parallel
     PollCache {
         #[pin]
-        poll_cache: PollCacheFuture<Res::Cached>,
+        poll_cache: PollCacheWithTagsFuture<Res::Cached>,
         state: Option<PollCache<Req, U>>,
     },
     /// Converting cached value to response (cache hit, no refill needed)
@@ -153,7 +258,7 @@ where
     /// Checking if response should be cached
     CheckResponseCachePolicy {
         #[pin]
-        cache_policy: BoxFuture<'static, ResponseCachePolicy<Res>>,
+        cache_policy: BoxFuture<'static, (ResponseCachePolicy<Res>, Option<Vec<CacheTag>>)>,
         state: Option<CheckResponseCachePolicy>,
     },
     /// Updating cache with response - context is captured in the future
@@ -166,13 +271,14 @@ where
     Response(Option<Response<Res>>),
 }
 
-impl<Res, Req, U, ReqP, E> Debug for State<'_, Res, Req, U, ReqP, E>
+impl<Res, Req, U, ReqP, E, ReqTE> Debug for State<'_, Res, Req, U, ReqP, E, ReqTE>
 where
     Res: CacheableResponse,
     Req: CacheableRequest,
     U: Upstream<Req, Response = Res>,
     ReqP: Predicate<Subject = Req>,
     E: Extractor<Subject = Req>,
+    ReqTE: TagExtractor<Subject = Req>,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -197,22 +303,24 @@ where
 // =============================================================================
 
 /// Data gathered from Initial state (synchronous).
-pub struct Initial<Req, ReqP, E, U> {
+pub struct Initial<Req, ReqP, E, U, ReqTE> {
     pub request: Req,
     pub predicates: ReqP,
     pub extractors: E,
+    pub tag_extractor: ReqTE,
     pub ctx: BoxContext,
     pub upstream: U,
     /// Tracing span for this state.
     pub span: Span,
 }
 
-impl<Req, ReqP, E, U> Initial<Req, ReqP, E, U> {
+impl<Req, ReqP, E, U, ReqTE> Initial<Req, ReqP, E, U, ReqTE> {
     /// Create a new Initial state with its tracing span.
     pub fn new(
         request: Req,
         predicates: ReqP,
         extractors: E,
+        tag_extractor: ReqTE,
         ctx: BoxContext,
         upstream: U,
         parent: &Span,
@@ -221,6 +329,7 @@ impl<Req, ReqP, E, U> Initial<Req, ReqP, E, U> {
             request,
             predicates,
             extractors,
+            tag_extractor,
             ctx,
             upstream,
             span: span!(parent: parent, Level::TRACE, "fsm.Initial"),
@@ -228,17 +337,18 @@ impl<Req, ReqP, E, U> Initial<Req, ReqP, E, U> {
     }
 }
 
-impl<Req, ReqP, E, U> Initial<Req, ReqP, E, U>
+impl<Req, ReqP, E, U, ReqTE> Initial<Req, ReqP, E, U, ReqTE>
 where
     Req: CacheableRequest + Send,
     ReqP: Predicate<Subject = Req> + Send + Sync,
     E: Extractor<Subject = Req> + Send + Sync,
     U: Upstream<Req>,
+    ReqTE: TagExtractor<Subject = Req> + Send + Sync,
 {
     /// Transition from Initial state.
     ///
     /// Based on policy configuration:
-    /// - Enabled: create CheckRequestCachePolicy future
+    /// - Enabled: create CheckRequestCachePolicy future (runs cache_policy + tag extraction)
     /// - Disabled: call upstream directly
     pub fn transition<'req>(self, policy: &PolicyConfig) -> InitialTransition<'req, Req, U>
     where
@@ -246,12 +356,19 @@ where
         ReqP: 'req,
         E: 'req,
         U: 'req,
+        ReqTE: 'req,
     {
         match policy {
             PolicyConfig::Enabled(_) => {
-                // Box the RPITIT future for storage in FSM state
-                let cache_policy_future =
-                    Box::pin(self.request.cache_policy(self.predicates, self.extractors));
+                let request = self.request;
+                let predicates = self.predicates;
+                let extractors = self.extractors;
+                let tag_extractor = self.tag_extractor;
+                let cache_policy_future = Box::pin(async move {
+                    request
+                        .cache_policy(predicates, extractors, tag_extractor)
+                        .await
+                });
                 InitialTransition::CheckRequestCachePolicy {
                     cache_policy_future,
                     ctx: self.ctx,
@@ -269,7 +386,7 @@ where
     }
 }
 
-impl<Req, ReqP, E, U> std::fmt::Debug for Initial<Req, ReqP, E, U> {
+impl<Req, ReqP, E, U, ReqTE> std::fmt::Debug for Initial<Req, ReqP, E, U, ReqTE> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Initial").finish_non_exhaustive()
     }
@@ -366,15 +483,23 @@ impl PollUpstream {
     ///
     /// This merges the old PollUpstream → UpstreamPolled → next state transitions
     /// into a single step, since UpstreamPolled was a synchronous state.
-    pub fn transition<Res, ResP>(
+    ///
+    /// `response_tag_extractor` is passed into `cache_policy` so tags are
+    /// extracted on `Res::Subject` (the same value the predicate checks).
+    /// All `CacheFuture` constructors materialize a concrete extractor
+    /// (defaulting to [`NeutralTagExtractor`] when none is configured), so
+    /// this is always present.
+    pub fn transition<Res, ResP, ResTE>(
         self,
         upstream_result: Res,
         predicates: ResP,
+        response_tag_extractor: ResTE,
         policy: &PolicyConfig,
     ) -> PollUpstreamTransition<Res>
     where
         Res: CacheableResponse + Send + 'static,
         ResP: Predicate<Subject = Res::Subject> + Send + Sync + 'static,
+        ResTE: TagExtractor<Subject = Res::Subject> + Send + Sync + 'static,
     {
         // Record upstream duration metric
         crate::metrics::record_upstream_duration(self.upstream_start.elapsed());
@@ -390,9 +515,10 @@ impl PollUpstream {
                 };
                 PollUpstreamTransition::CheckResponseCachePolicy {
                     cache_policy_future: Box::pin(async move {
-                        upstream_result
-                            .cache_policy(predicates, &entity_config)
-                            .await
+                        let (policy, tags) = upstream_result
+                            .cache_policy(predicates, response_tag_extractor, &entity_config)
+                            .await;
+                        (policy, Some(tags))
                     }),
                     permit: self.permit,
                     ctx: self.ctx,
@@ -460,9 +586,15 @@ impl CheckResponseCachePolicy {
     }
 
     /// Transition from CheckResponseCachePolicy state after future completes.
+    ///
+    /// `response_tags` carries tags extracted from the upstream response by
+    /// the response tag extractor (if configured). When `Some`, the tags are
+    /// attached to the `CacheValue` before write so they can be checked for
+    /// invalidation on future reads.
     pub fn transition<Res, B, C>(
         self,
         policy: CachePolicy<CacheValue<Res::Cached>, Res>,
+        response_tags: Option<Vec<CacheTag>>,
         backend: Arc<B>,
         concurrency_manager: &C,
     ) -> CheckResponseCachePolicyTransition<Res>
@@ -485,6 +617,11 @@ impl CheckResponseCachePolicy {
                 }
                 let cache_key = self.cache_key;
                 let mut ctx = self.ctx;
+                // Attach response tags before write if any were extracted.
+                let cache_value = match response_tags {
+                    Some(response_tags) => cache_value.with_tags(CacheTags::response_only(response_tags)),
+                    None => cache_value,
+                };
                 let update_cache_future = Box::pin(async move {
                     let update_cache_result =
                         backend.set::<Res>(&cache_key, &cache_value, &mut ctx).await;
@@ -549,6 +686,7 @@ impl<U> CheckRequestCachePolicy<U> {
     pub fn transition<Req, Res, B>(
         self,
         policy: RequestCachePolicy<Req>,
+        request_tags: Vec<CacheTag>,
         backend: Arc<B>,
         cache_key_storage: &mut Option<CacheKey>,
     ) -> CheckRequestCachePolicyTransition<Req, Res, U>
@@ -570,7 +708,8 @@ impl<U> CheckRequestCachePolicy<U> {
                 debug!(?key, "FSM looking up cache key");
                 let _ = cache_key_storage.insert(key.clone());
                 let mut ctx = self.ctx;
-                let poll_cache = Box::pin(async move {
+                let backend_for_tags = backend.clone();
+                let cache_future = Box::pin(async move {
                     let result = backend.get::<Res>(&cache_key_for_get, &mut ctx).await;
                     debug!(
                         found = result.as_ref().map(|r| r.is_some()).unwrap_or(false),
@@ -578,6 +717,15 @@ impl<U> CheckRequestCachePolicy<U> {
                     );
                     (result, ctx)
                 });
+                // Build tag invalidation future only if there are request tags to check
+                let tag_future: Option<TagInvalidationFuture> = if request_tags.is_empty() {
+                    None
+                } else {
+                    Some(Box::pin(async move {
+                        backend_for_tags.invalidated(&request_tags).await
+                    }))
+                };
+                let poll_cache = PollCacheWithTagsFuture::new(cache_future, tag_future);
                 CheckRequestCachePolicyTransition::PollCache {
                     poll_cache,
                     request,
@@ -634,9 +782,14 @@ impl<Req, U> PollCache<Req, U> {
     ///
     /// On cache miss or expired, checks concurrency policy and transitions directly
     /// to either `ConcurrentPollUpstream` or `PollUpstream`.
+    ///
+    /// `tag_invalidation` is the result of querying request-tag invalidation timestamps
+    /// in parallel with the cache read. If any tag was invalidated after the entry's
+    /// `created` timestamp, the entry is treated as expired.
     pub fn transition<Res, B, C>(
         self,
         cache_result: CacheResult<Res::Cached>,
+        tag_invalidation: Option<TagInvalidationResult>,
         mut ctx: BoxContext,
         backend: Arc<B>,
         policy: &PolicyConfig,
@@ -655,6 +808,42 @@ impl<Req, U> PollCache<Req, U> {
 
         match cached {
             Some(cached_value) => {
+                // Check tag invalidation BEFORE TTL-based cache state.
+                // If any request tag was invalidated after the entry was created,
+                // treat the entry as expired (force upstream fetch).
+                if let Some(tag_result) = tag_invalidation {
+                    match tag_result {
+                        Ok(timestamps) if !timestamps.is_empty() => {
+                            let entry_created = cached_value.created();
+                            let invalidated =
+                                timestamps.values().any(|&ts| ts > entry_created);
+                            if invalidated {
+                                debug!(
+                                    "Cache entry invalidated by tag (created={}, latest_tag_ts={:?})",
+                                    entry_created,
+                                    timestamps.values().max()
+                                );
+                                ctx.set_status(CacheStatus::Miss);
+                                return self.transition_to_upstream(
+                                    ctx,
+                                    policy,
+                                    concurrency_manager,
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            warn!("Tag invalidation check failed: {err:?}");
+                            ctx.set_status(CacheStatus::Miss);
+                            return self.transition_to_upstream(
+                                ctx,
+                                policy,
+                                concurrency_manager,
+                            );
+                        }
+                        _ => {}
+                    }
+                }
+
                 let cache_state = cached_value.cache_state();
                 ctx.set_status(CacheStatus::Hit);
 

--- a/hitbox/src/fsm/transitions.rs
+++ b/hitbox/src/fsm/transitions.rs
@@ -14,10 +14,11 @@ use tracing::Span;
 
 use crate::fsm::states::{
     AwaitResponse, AwaitResponseFuture, CheckRequestCachePolicy, CheckResponseCachePolicy,
-    ConvertResponse, ConvertResponseFuture, HandleStale, PollCache, PollCacheFuture, PollUpstream,
-    RequestCachePolicyFuture, Response, State, UpdateCache, UpdateCacheFuture,
+    ConvertResponse, ConvertResponseFuture, HandleStale, PollCache, PollCacheWithTagsFuture,
+    PollUpstream, RequestCachePolicyFuture, Response, State, UpdateCache, UpdateCacheFuture,
 };
 use crate::{CacheKey, CacheableRequest, CacheableResponse, Extractor, Predicate};
+use hitbox_core::tag::TagExtractor;
 
 // =============================================================================
 // InitialTransition
@@ -47,12 +48,16 @@ where
     Req: CacheableRequest + 'req,
     U: Upstream<Req> + 'req,
 {
-    pub fn into_state<Res, ReqP, E>(self, parent: &Span) -> State<'req, Res, Req, U, ReqP, E>
+    pub fn into_state<Res, ReqP, E, ReqTE>(
+        self,
+        parent: &Span,
+    ) -> State<'req, Res, Req, U, ReqP, E, ReqTE>
     where
         Res: CacheableResponse,
         U: Upstream<Req, Response = Res>,
         ReqP: Predicate<Subject = Req>,
         E: Extractor<Subject = Req>,
+        ReqTE: TagExtractor<Subject = Req>,
     {
         match self {
             InitialTransition::CheckRequestCachePolicy {
@@ -103,9 +108,9 @@ where
     Res: CacheableResponse,
     U: Upstream<Req, Response = Res>,
 {
-    /// Request is cacheable - poll cache
+    /// Request is cacheable - poll cache (with parallel tag invalidation check)
     PollCache {
-        poll_cache: PollCacheFuture<Res::Cached>,
+        poll_cache: PollCacheWithTagsFuture<Res::Cached>,
         request: Req,
         cache_key: CacheKey,
         upstream: U,
@@ -122,12 +127,16 @@ where
     Res: CacheableResponse,
     U: Upstream<Req, Response = Res>,
 {
-    pub fn into_state<'req, ReqP, E>(self, parent: &Span) -> State<'req, Res, Req, U, ReqP, E>
+    pub fn into_state<'req, ReqP, E, ReqTE>(
+        self,
+        parent: &Span,
+    ) -> State<'req, Res, Req, U, ReqP, E, ReqTE>
     where
         Req: CacheableRequest + 'req,
         U: 'req,
         ReqP: Predicate<Subject = Req>,
         E: Extractor<Subject = Req>,
+        ReqTE: TagExtractor<Subject = Req>,
     {
         match self {
             CheckRequestCachePolicyTransition::PollCache {
@@ -217,12 +226,16 @@ where
     Res: CacheableResponse,
     U: Upstream<Req, Response = Res>,
 {
-    pub fn into_state<'req, ReqP, E>(self, parent: &Span) -> State<'req, Res, Req, U, ReqP, E>
+    pub fn into_state<'req, ReqP, E, ReqTE>(
+        self,
+        parent: &Span,
+    ) -> State<'req, Res, Req, U, ReqP, E, ReqTE>
     where
         Req: CacheableRequest + 'req,
         U: 'req,
         ReqP: Predicate<Subject = Req>,
         E: Extractor<Subject = Req>,
+        ReqTE: TagExtractor<Subject = Req>,
     {
         match self {
             PollCacheTransition::UpdateCache {
@@ -307,16 +320,17 @@ pub enum ConvertResponseTransition<Res> {
 }
 
 impl<Res> ConvertResponseTransition<Res> {
-    pub fn into_state<'req, Req, U, ReqP, E>(
+    pub fn into_state<'req, Req, U, ReqP, E, ReqTE>(
         self,
         parent: &Span,
-    ) -> State<'req, Res, Req, U, ReqP, E>
+    ) -> State<'req, Res, Req, U, ReqP, E, ReqTE>
     where
         Res: CacheableResponse,
         Req: CacheableRequest + 'req,
         U: Upstream<Req, Response = Res> + 'req,
         ReqP: Predicate<Subject = Req>,
         E: Extractor<Subject = Req>,
+        ReqTE: TagExtractor<Subject = Req>,
     {
         match self {
             ConvertResponseTransition::Response(s) => {
@@ -361,12 +375,16 @@ where
     Res: CacheableResponse,
     U: Upstream<Req, Response = Res>,
 {
-    pub fn into_state<'req, ReqP, E>(self, parent: &Span) -> State<'req, Res, Req, U, ReqP, E>
+    pub fn into_state<'req, ReqP, E, ReqTE>(
+        self,
+        parent: &Span,
+    ) -> State<'req, Res, Req, U, ReqP, E, ReqTE>
     where
         Req: CacheableRequest + 'req,
         U: 'req,
         ReqP: Predicate<Subject = Req>,
         E: Extractor<Subject = Req>,
+        ReqTE: TagExtractor<Subject = Req>,
     {
         match self {
             HandleStaleTransition::Response(s) => {
@@ -422,12 +440,16 @@ where
     Res: CacheableResponse,
     U: Upstream<Req, Response = Res>,
 {
-    pub fn into_state<'req, ReqP, E>(self, parent: &Span) -> State<'req, Res, Req, U, ReqP, E>
+    pub fn into_state<'req, ReqP, E, ReqTE>(
+        self,
+        parent: &Span,
+    ) -> State<'req, Res, Req, U, ReqP, E, ReqTE>
     where
         Req: CacheableRequest + 'req,
         U: 'req,
         ReqP: Predicate<Subject = Req>,
         E: Extractor<Subject = Req>,
+        ReqTE: TagExtractor<Subject = Req>,
     {
         match self {
             AwaitResponseTransition::Response(s) => {
@@ -470,9 +492,19 @@ pub enum PollUpstreamTransition<Res>
 where
     Res: CacheableResponse,
 {
-    /// Proceed to check response cache policy
+    /// Proceed to check response cache policy.
+    ///
+    /// The future returns both the cache policy and any response tags
+    /// extracted from the upstream response (`Vec::new()` when no
+    /// response tag extractor is configured).
     CheckResponseCachePolicy {
-        cache_policy_future: BoxFuture<'static, ResponseCachePolicy<Res>>,
+        cache_policy_future: BoxFuture<
+            'static,
+            (
+                ResponseCachePolicy<Res>,
+                Option<Vec<hitbox_core::tag::CacheTag>>,
+            ),
+        >,
         permit: Option<OwnedSemaphorePermit>,
         ctx: BoxContext,
         cache_key: CacheKey,
@@ -485,15 +517,16 @@ impl<Res> PollUpstreamTransition<Res>
 where
     Res: CacheableResponse,
 {
-    pub fn into_state<'req, Req, U, ReqP, E>(
+    pub fn into_state<'req, Req, U, ReqP, E, ReqTE>(
         self,
         parent: &Span,
-    ) -> State<'req, Res, Req, U, ReqP, E>
+    ) -> State<'req, Res, Req, U, ReqP, E, ReqTE>
     where
         Req: CacheableRequest + 'req,
         U: Upstream<Req, Response = Res> + 'req,
         ReqP: Predicate<Subject = Req>,
         E: Extractor<Subject = Req>,
+        ReqTE: TagExtractor<Subject = Req>,
     {
         match self {
             PollUpstreamTransition::CheckResponseCachePolicy {
@@ -549,15 +582,16 @@ impl<Res> CheckResponseCachePolicyTransition<Res>
 where
     Res: CacheableResponse,
 {
-    pub fn into_state<'req, Req, U, ReqP, E>(
+    pub fn into_state<'req, Req, U, ReqP, E, ReqTE>(
         self,
         parent: &Span,
-    ) -> State<'req, Res, Req, U, ReqP, E>
+    ) -> State<'req, Res, Req, U, ReqP, E, ReqTE>
     where
         Req: CacheableRequest + 'req,
         U: Upstream<Req, Response = Res> + 'req,
         ReqP: Predicate<Subject = Req>,
         E: Extractor<Subject = Req>,
+        ReqTE: TagExtractor<Subject = Req>,
     {
         match self {
             CheckResponseCachePolicyTransition::UpdateCache {
@@ -597,16 +631,17 @@ pub enum UpdateCacheTransition<Res> {
 }
 
 impl<Res> UpdateCacheTransition<Res> {
-    pub fn into_state<'req, Req, U, ReqP, E>(
+    pub fn into_state<'req, Req, U, ReqP, E, ReqTE>(
         self,
         parent: &Span,
-    ) -> State<'req, Res, Req, U, ReqP, E>
+    ) -> State<'req, Res, Req, U, ReqP, E, ReqTE>
     where
         Res: CacheableResponse,
         Req: CacheableRequest + 'req,
         U: Upstream<Req, Response = Res> + 'req,
         ReqP: Predicate<Subject = Req>,
         E: Extractor<Subject = Req>,
+        ReqTE: TagExtractor<Subject = Req>,
     {
         match self {
             UpdateCacheTransition::Response(s) => {

--- a/hitbox/src/lib.rs
+++ b/hitbox/src/lib.rs
@@ -106,6 +106,14 @@ pub mod extractor {
     pub use hitbox_core::Extractor;
 }
 
+/// Cache tag types and tag extractors.
+///
+/// Re-exports the tag invalidation primitives from
+/// [`hitbox-core`](https://docs.rs/hitbox-core).
+pub mod tag {
+    pub use hitbox_core::tag::*;
+}
+
 /// The `hitbox` prelude.
 ///
 /// Provides convenient access to the most commonly used types:

--- a/hitbox/src/policy.rs
+++ b/hitbox/src/policy.rs
@@ -4,5 +4,5 @@
 
 pub use hitbox_core::policy::{
     CacheBehaviorPolicy, ConcurrencyLimit, EnabledCacheConfig, PolicyConfig, PolicyConfigBuilder,
-    StalePolicy,
+    StalePolicy, TagInvalidation,
 };


### PR DESCRIPTION
Adds passive tag-based invalidation modeled on FusionCache: cache entries carry a set of tags, backends store invalidation timestamps per tag, and on read the FSM compares per-tag timestamps against the entry's creation time. No tag→keys index, no eager eviction — entries are treated as expired when any of their tags has a newer invalidation timestamp.

FSM integration runs request-side tag invalidation prefetch in parallel with the cache read, attaches response-side tags at write time, and short-circuits the parallel fetch when no tags are configured (zero overhead for non-tag flows).

Includes BDD coverage for invalidation behavior and backend-level tag round-trip / invalidate / invalidated tests across Moka, FeOxDb, and Redis.